### PR TITLE
implicit context (tentative)

### DIFF
--- a/LeanMachines/Event/Basic.lean
+++ b/LeanMachines/Event/Basic.lean
@@ -43,7 +43,7 @@ This comprises:
 
 -/
 
-class Machine (CTX : outParam (Type u)) (M)
+class Machine {CTX : outParam (Type u)} (M)
   extends Inhabited M where
   /-- The context (i.e. parameters) of the machine. -/
   context : CTX
@@ -80,11 +80,11 @@ with: `M` the machine type,
 This extends `_EventRoot` with a notion of (deterministic/functional) action.
 .-/
 @[ext]
-structure _Event (M) [Machine CTX M] (α : Type) (β : Type) where
+structure _Event (M) [@Machine CTX M] (α : Type) (β : Type) where
   guard (m : M) (x : α) : Prop := True
   action (m : M) (x : α) (grd : guard m x): (β × M)
 
-theorem _Guard_ext [Machine CTX M] (guard₁ : M → α → Prop) (guard₂ : M → α → Prop):
+theorem _Guard_ext [@Machine CTX M] (guard₁ : M → α → Prop) (guard₂ : M → α → Prop):
   (∀ m x, guard₁ m x = guard₂ m x)
   → guard₁ = guard₂ :=
 by
@@ -92,7 +92,7 @@ by
   funext m x
   exact H m x
 
-theorem _Guard_coext [Machine CTX M] (guard₁ : M → α → Prop) (guard₂ : M → α → Prop):
+theorem _Guard_coext [@Machine CTX M] (guard₁ : M → α → Prop) (guard₂ : M → α → Prop):
   guard₁ = guard₂
   → ∀ m x, guard₁ m x = guard₂ m x
  :=
@@ -103,12 +103,12 @@ by
 
 /- XXX : does this axiom breaks something ?
          (I don't think it's provable because of HEq) -/
-axiom _Action_ext_ax {CTX} {M} [Machine CTX M] {α β} (ev₁ ev₂: _Event M α β):
+axiom _Action_ext_ax {CTX} {M} [@Machine CTX M] {α β} (ev₁ ev₂: _Event M α β):
    (∀ m x, ev₁.guard m x = ev₂.guard m x
           ∧ ∀ grd₁ grd₂, ev₁.action m x grd₁ = ev₂.action m x grd₂)
    → HEq ev₁.action ev₂.action
 
-theorem _Event.ext' {CTX} {M} [Machine CTX M] {α β} (ev₁ ev₂: _Event M α β):
+theorem _Event.ext' {CTX} {M} [@Machine CTX M] {α β} (ev₁ ev₂: _Event M α β):
   (∀ m x, ev₁.guard m x = ev₂.guard m x
           ∧ ∀ grd₁ grd₂, ev₁.action m x grd₁ = ev₂.action m x grd₂)
   → ev₁ = ev₂ :=
@@ -134,12 +134,12 @@ with: `M` the machine type,
 `α` the input type, and `β` the output type of the event
 .-/
 @[ext]
-structure _InitEvent (M) [Machine CTX M] (α) (β : Type) where
+structure _InitEvent (M) [@Machine CTX M] (α) (β : Type) where
   guard (x : α) : Prop := True
   init (x : α) (grd : guard x) : (β × M)
 
 @[simp]
-def _InitEvent.to_Event [DecidableEq M] [Machine CTX M] (ev : _InitEvent M α β) : _Event M α β :=
+def _InitEvent.to_Event [DecidableEq M] [@Machine CTX M] (ev : _InitEvent M α β) : _Event M α β :=
   {
     guard := fun m x => m == default ∧ ev.guard x
     action := fun m x grd => ev.init x (by simp at grd ; apply grd.2)
@@ -150,7 +150,7 @@ Note that the output type must match the input type,
  hence a non-deterministic notion of skip event is
  best in most situations (cf. `_NDEvent` in the `NonDet` module). -/
 @[simp]
-def skip_Event (M) [Machine CTX M] (α) : _Event M α α :=
+def skip_Event (M) [@Machine CTX M] (α) : _Event M α α :=
 {
   action := fun m x _ => (x, m)
 }
@@ -158,14 +158,14 @@ def skip_Event (M) [Machine CTX M] (α) : _Event M α α :=
 /-- Any type-theoretic function can be lifted to the
 status of a (non-guarded) event. -/
 @[simp]
-def fun_Event  (M) [Machine CTX M] (f : α → β) : _Event M α β :=
+def fun_Event  (M) [@Machine CTX M] (f : α → β) : _Event M α β :=
 {
   action := fun m x _ => (f x, m)
 }
 
 /-- This allows to lift a "stateful" function. -/
 @[simp]
-def funskip_Event (M) [Machine CTX M] (xf : M → α → β) : _Event M α β :=
+def funskip_Event (M) [@Machine CTX M] (xf : M → α → β) : _Event M α β :=
 {
   action := fun m x _ => (xf m x, m)
 }
@@ -183,16 +183,16 @@ This part is rather experimental and is thus not fully documented yet.
 
 /- Functor -/
 
-def map_Event [Machine CTX M] (f : α → β) (ev : _Event M γ α)  : _Event M γ β :=
+def map_Event [@Machine CTX M] (f : α → β) (ev : _Event M γ α)  : _Event M γ β :=
   { guard := ev.guard
     action := fun m x grd => let (y, m') := (ev.action m x grd)
                              (f y, m')
    }
 
-instance [Machine CTX M]: Functor (_Event M γ) where
+instance [@Machine CTX M]: Functor (_Event M γ) where
   map := map_Event
 
-instance [Machine CTX M]: LawfulFunctor (_Event M γ) where
+instance [@Machine CTX M]: LawfulFunctor (_Event M γ) where
   map_const := by
     intros α β
     simp [Functor.mapConst, Functor.map]
@@ -206,15 +206,15 @@ instance [Machine CTX M]: LawfulFunctor (_Event M γ) where
 /- Applicative Functor -/
 
 @[simp]
-def pure_Event [Machine CTX M] (y : α) : _Event M γ α :=
+def pure_Event [@Machine CTX M] (y : α) : _Event M γ α :=
   {
     action := fun m _ _ => (y, m)
   }
 
-instance [Machine CTX M]: Pure (_Event M γ) where
+instance [@Machine CTX M]: Pure (_Event M γ) where
   pure := pure_Event
 
-def apply_Event [Machine CTX M] ( ef : _Event M γ (α → β)) (ev : _Event M γ α) : _Event M γ β :=
+def apply_Event [@Machine CTX M] ( ef : _Event M γ (α → β)) (ev : _Event M γ α) : _Event M γ β :=
   {
     guard := fun m x => ef.guard m x ∧ ((efg : ef.guard m x)
                                          →  ev.guard (ef.action m x efg).snd x)
@@ -222,10 +222,10 @@ def apply_Event [Machine CTX M] ( ef : _Event M γ (α → β)) (ev : _Event M �
                              ((ef.action m x grd.1).1 y, m'')
   }
 
-instance [Machine CTX M]: Applicative (_Event M γ) where
+instance [@Machine CTX M]: Applicative (_Event M γ) where
   seq ef ev := apply_Event ef (ev ())
 
-theorem Pure_seq_aux [Machine CTX M] (g : α → β) (ev : _Event M γ α):
+theorem Pure_seq_aux [@Machine CTX M] (g : α → β) (ev : _Event M γ α):
   apply_Event (pure g) ev = map_Event g ev :=
 by
   apply _Event.ext'
@@ -233,7 +233,7 @@ by
   simp [apply_Event, pure, map_Event]
 
 
-instance [Machine CTX M]: LawfulApplicative (_Event M γ) where
+instance [@Machine CTX M]: LawfulApplicative (_Event M γ) where
   map_const := by intros ; rfl
   id_map := by intros ; rfl
   seqLeft_eq := by intros ; rfl
@@ -267,7 +267,7 @@ instance [Machine CTX M]: LawfulApplicative (_Event M γ) where
 
 /- Monad -/
 
-def bind_Event [Machine CTX M] (ev : _Event M γ α) (f : α → _Event M γ β) : _Event M γ β :=
+def bind_Event [@Machine CTX M] (ev : _Event M γ α) (f : α → _Event M γ β) : _Event M γ β :=
   {
     guard := fun m x => ev.guard m x ∧
                         ((grd : ev.guard m x) →
@@ -279,10 +279,10 @@ def bind_Event [Machine CTX M] (ev : _Event M γ α) (f : α → _Event M γ β)
   }
 
 
-instance [Machine CTX M]: Monad (_Event M γ) where
+instance [@Machine CTX M]: Monad (_Event M γ) where
   bind := bind_Event
 
-instance [Machine CTX M]: LawfulMonad (_Event M γ) where
+instance [@Machine CTX M]: LawfulMonad (_Event M γ) where
   bind_pure_comp := by
     intros α β f ev
     simp [pure, Functor.map, bind]
@@ -315,10 +315,10 @@ instance [Machine CTX M]: LawfulMonad (_Event M γ) where
 
 /- arrows -/
 
-abbrev _KEvent M [Machine CTX M] γ := Kleisli (_Event M γ)
+abbrev _KEvent M [@Machine CTX M] γ := Kleisli (_Event M γ)
   -- α → (_Event M γ) β
 
---def instArrowKEvent [Machine CTX M]: Arrow (_KEvent M γ) := inferInstance
+--def instArrowKEvent [@Machine CTX M]: Arrow (_KEvent M γ) := inferInstance
 
 /-
 variable (f : α → β)
@@ -332,7 +332,7 @@ variable (γ)
 -- but Events are monads in their output type
 -- and both monads and arrows do not apply on input types
 
-instance [Machine CTX M]: Category (_Event M) where
+instance [@Machine CTX M]: Category (_Event M) where
   id := fun_Event M id
 
   comp {α β γ} (ev₂ : _Event M β γ) (ev₁ : _Event M α β) : _Event M α γ :=
@@ -342,7 +342,7 @@ instance [Machine CTX M]: Category (_Event M) where
       action := fun m x grd => ev₂.action (ev₁.action m x grd.1).2 (ev₁.action m x grd.1).1 (grd.2 grd.1)
     }
 
-instance [Machine CTX M]: LawfulCategory (_Event M) where
+instance [@Machine CTX M]: LawfulCategory (_Event M) where
   id_right ev := by
     apply _Event.ext
     case guard => simp
@@ -367,14 +367,14 @@ instance [Machine CTX M]: LawfulCategory (_Event M) where
       constructor <;> intro H <;> simp [H]
 
 @[simp]
-def _Event_Arrow_first [Machine CTX M] (ev : _Event M α β) : _Event M (α × γ) (β × γ) :=
+def _Event_Arrow_first [@Machine CTX M] (ev : _Event M α β) : _Event M (α × γ) (β × γ) :=
   { guard := fun m (x, _) => ev.guard m x
     action := fun m (x, y) grd => let (x', m') := ev.action m x grd
                               ((x',y), m')
   }
 
 /- one possible definition
-instance [Machine CTX M]: Arrow (_Event M) where
+instance [@Machine CTX M]: Arrow (_Event M) where
   arrow {α β} (f : α → β) := fun_Event M f
 
   split {α α' β β'} (ev₁ : _Event M α β)  (ev₂ : _Event M α' β') : _Event M (α × α') (β × β') :=
@@ -385,7 +385,7 @@ instance [Machine CTX M]: Arrow (_Event M) where
 
 -- more explicit alternative
 
-instance [Machine CTX M]: Arrow (_Event M) where
+instance [@Machine CTX M]: Arrow (_Event M) where
   arrow {α β} (f : α → β) := {
     guard := fun _ _ => True
     action := fun m x _ => (f x, m)
@@ -401,7 +401,7 @@ instance [Machine CTX M]: Arrow (_Event M) where
 
 
 
-instance [Machine CTX M]: LawfulArrow (_Event M) where
+instance [@Machine CTX M]: LawfulArrow (_Event M) where
   arrow_id := by simp [Arrow.arrow]
   arrow_ext _ := by
     apply _Event.ext'
@@ -421,39 +421,39 @@ instance [Machine CTX M]: LawfulArrow (_Event M) where
 
 /- ContravariantFunctor functor -/
 
-abbrev _CoEvent (M) [Machine CTX M] (α) (β) :=
+abbrev _CoEvent (M) [@Machine CTX M] (α) (β) :=
   _Event M β α
 
 @[simp]
-def coEvent_from_Event [Machine CTX M] (ev : _Event M α β) : _CoEvent M β α :=
+def coEvent_from_Event [@Machine CTX M] (ev : _Event M α β) : _CoEvent M β α :=
  ev
 
 @[simp]
-def Event_from_CoEvent [Machine CTX M] (ev : _CoEvent M β α) : _Event M α β :=
+def Event_from_CoEvent [@Machine CTX M] (ev : _CoEvent M β α) : _Event M α β :=
  ev
 
-instance [Machine CTX M] : ContravariantFunctor (_CoEvent M γ) where
+instance [@Machine CTX M] : ContravariantFunctor (_CoEvent M γ) where
   contramap f ev := {
     guard := fun m x => ev.guard m (f x)
     action := fun m x => ev.action m (f x)
   }
 
-instance [Machine CTX M] : LawfullContravariantFunctor (_CoEvent M β) where
+instance [@Machine CTX M] : LawfullContravariantFunctor (_CoEvent M β) where
   cmap_id _ := rfl
   cmap_comp _ _ := rfl
 
 /- Profunctor -/
 
-instance [Machine CTX M] : Profunctor (_Event M) where
+instance [@Machine CTX M] : Profunctor (_Event M) where
   dimap {α β} {γ δ} (f : β → α) (g : γ → δ) (ev : _Event M α γ) : _Event M β δ :=
     let ev' := Event_from_CoEvent (ContravariantFunctor.contramap f (coEvent_from_Event ev))
     Functor.map g ev'
 
-instance [Machine CTX M] : LawfulProfunctor (_Event M) where
+instance [@Machine CTX M] : LawfulProfunctor (_Event M) where
   dimap_id := rfl
   dimap_comp _ _ _ _ := rfl
 
-instance [Machine CTX M] : StrongProfunctor (_Event M) where
+instance [@Machine CTX M] : StrongProfunctor (_Event M) where
   first' {α β γ} (ev : _Event M α β): _Event M (α × γ) (β × γ) :=
     {
       guard := fun m (x, _) => ev.guard m x
@@ -461,7 +461,7 @@ instance [Machine CTX M] : StrongProfunctor (_Event M) where
                                     ((x', y), m')
     }
 
-instance [Machine CTX M] : LawfulStrongProfunctor (_Event M) where
+instance [@Machine CTX M] : LawfulStrongProfunctor (_Event M) where
 
 
 /-  Other combinators -/
@@ -469,7 +469,7 @@ instance [Machine CTX M] : LawfulStrongProfunctor (_Event M) where
 
 open Either
 
-def altEvent [Machine CTX M] (evl : _Event M α α') (evr : _Event M β β')
+def altEvent [@Machine CTX M] (evl : _Event M α α') (evr : _Event M β β')
   : _Event M (Either α β) (Either α' β') :=
   {
     guard := fun m x => match x with

--- a/LeanMachines/Event/Convergent.lean
+++ b/LeanMachines/Event/Convergent.lean
@@ -39,7 +39,7 @@ natural numbers (type `Nat`), or subset ordering for finite sets
 /-- The definition of a `variant` of type `v` obtained from
 a machine pre-state. The type `v` must be a preorder
 (i.e. an instance of the `Preorder` typeclass). -/
-structure _Variant (v) [Preorder v] [instM:Machine CTX M] where
+structure _Variant (v) [Preorder v] [instM:@Machine CTX M] where
   variant : M → v
 
 /-!
@@ -47,7 +47,7 @@ structure _Variant (v) [Preorder v] [instM:Machine CTX M] where
 -/
 
 /-- The internal representation of proof obligations for anticipated events. -/
-structure _AnticipatedEventPO (v) [Preorder v] [instM: Machine CTX M] (ev : _Event M α β) (kind : EventKind)
+structure _AnticipatedEventPO (v) [Preorder v] [instM:@Machine CTX M] (ev : _Event M α β) (kind : EventKind)
           extends _Variant v (instM:=instM), _EventPO ev kind  where
 
   nonIncreasing (m : M) (x : α):
@@ -60,12 +60,12 @@ structure _AnticipatedEventPO (v) [Preorder v] [instM: Machine CTX M] (ev : _Eve
 It is an event for machine type `M` with input type `α` and output type `β`.
 The non-increasing argument is based on the variant type `v` assumed
 to be a preorder. -/
-structure AnticipatedEvent (v) [Preorder v] (M) [Machine CTX M] (α) (β)
+structure AnticipatedEvent (v) [Preorder v] (M) [@Machine CTX M] (α) (β)
           extends (_Event M α β)  where
   po : _AnticipatedEventPO v to_Event (EventKind.TransDet Convergence.Anticipated)
 
 @[simp]
-private def AnticipatedEvent_fromOrdinary {v} [Preorder v] {M} [Machine CTX M] (ev : OrdinaryEvent M α β)
+private def AnticipatedEvent_fromOrdinary {v} [Preorder v] {M} [@Machine CTX M] (ev : OrdinaryEvent M α β)
   (variant : M → v)
   (Hnincr: ∀ (m : M) (x : α),
     Machine.invariant m
@@ -84,7 +84,7 @@ private def AnticipatedEvent_fromOrdinary {v} [Preorder v] {M} [Machine CTX M] (
 
 /-- The "downgrading" of an anticipated event to an ordinary one. -/
 @[simp]
-def AnticipatedEvent.toOrdinaryEvent [Preorder v] [Machine CTX M]
+def AnticipatedEvent.toOrdinaryEvent [Preorder v] [@Machine CTX M]
   (ev : AnticipatedEvent v M α β) : OrdinaryEvent M α β :=
   {
     to_Event := ev.to_Event
@@ -99,7 +99,7 @@ with input type `α` and output type `β`. The non-increasing proof relies
 Note that the guard, action and safety PO of the event must be also
 specified, as in the ordinary case (cf. `OrdinaryEventSpec`).
   -/
-structure AnticipatedEventSpec (v) [Preorder v] {CTX} (M) [instM: Machine CTX M] (α) (β)
+structure AnticipatedEventSpec (v) [Preorder v] {CTX} (M) [instM:@Machine CTX M] (α) (β)
   extends _Variant v (instM:=instM), EventSpec M α β where
   /-- Proof obligation: the variant is non-increasing. -/
   nonIncreasing (m : M) (x : α):
@@ -111,11 +111,11 @@ structure AnticipatedEventSpec (v) [Preorder v] {CTX} (M) [instM: Machine CTX M]
 /-- Construction of an anticipated deterministic event from a
 `AnticipatedEventSpec` specification. -/
 @[simp]
-def newAnticipatedEvent {v} [Preorder v] {M} [Machine CTX M] (ev : AnticipatedEventSpec v M α β) : AnticipatedEvent v M α β :=
+def newAnticipatedEvent {v} [Preorder v] {M} [@Machine CTX M] (ev : AnticipatedEventSpec v M α β) : AnticipatedEvent v M α β :=
   AnticipatedEvent_fromOrdinary (newEvent ev.toEventSpec) ev.to_Variant.variant ev.nonIncreasing
 
 /-- Variant of `AnticipatedEventSpec` with implicit `Unit` output type -/
-structure AnticipatedEventSpec' (v) [Preorder v] (M) [instM:Machine CTX M] (α)
+structure AnticipatedEventSpec' (v) [Preorder v] (M) [instM:@Machine CTX M] (α)
   extends _Variant v (instM:=instM), EventSpec' M α where
 
   nonIncreasing (m : M) (x : α):
@@ -125,7 +125,7 @@ structure AnticipatedEventSpec' (v) [Preorder v] (M) [instM:Machine CTX M] (α)
       variant m' ≤ variant m
 
 @[simp]
-def AnticipatedEventSpec'.toAnticipatedEventSpec {v} [Preorder v] {M} [Machine CTX M] (ev : AnticipatedEventSpec' v M α) : AnticipatedEventSpec v M α Unit :=
+def AnticipatedEventSpec'.toAnticipatedEventSpec {v} [Preorder v] {M} [@Machine CTX M] (ev : AnticipatedEventSpec' v M α) : AnticipatedEventSpec v M α Unit :=
   {
     toEventSpec := ev.toEventSpec
     variant := ev.variant
@@ -134,11 +134,11 @@ def AnticipatedEventSpec'.toAnticipatedEventSpec {v} [Preorder v] {M} [Machine C
 
 /-- Variant of `newAnticipatedEvent` with implicit `Unit` output type -/
 @[simp]
-def newAnticipatedEvent' {v} [Preorder v] {M} [Machine CTX M] (ev : AnticipatedEventSpec' v M α ) : AnticipatedEvent v M α Unit :=
+def newAnticipatedEvent' {v} [Preorder v] {M} [@Machine CTX M] (ev : AnticipatedEventSpec' v M α ) : AnticipatedEvent v M α Unit :=
   newAnticipatedEvent ev.toAnticipatedEventSpec
 
 /-- Variant of `AnticipatedEventSpec` with implicit `Unit` input and output types -/
-structure AnticipatedEventSpec'' (v) [Preorder v] (M) [instM:Machine CTX M]
+structure AnticipatedEventSpec'' (v) [Preorder v] (M) [instM:@Machine CTX M]
   extends _Variant v (instM:=instM), EventSpec'' M where
 
   nonIncreasing (m : M):
@@ -148,7 +148,7 @@ structure AnticipatedEventSpec'' (v) [Preorder v] (M) [instM:Machine CTX M]
       variant m' ≤ variant m
 
 @[simp]
-def AnticipatedEventSpec''.toAnticipatedEventSpec {v} [Preorder v] {M} [Machine CTX M] (ev : AnticipatedEventSpec'' v M) : AnticipatedEventSpec v M Unit Unit :=
+def AnticipatedEventSpec''.toAnticipatedEventSpec {v} [Preorder v] {M} [@Machine CTX M] (ev : AnticipatedEventSpec'' v M) : AnticipatedEventSpec v M Unit Unit :=
   {
     toEventSpec := ev.toEventSpec
     variant := ev.variant
@@ -157,7 +157,7 @@ def AnticipatedEventSpec''.toAnticipatedEventSpec {v} [Preorder v] {M} [Machine 
 
 /-- Variant of `newAnticipatedEvent` with implicit `Unit` input and output types -/
 @[simp]
-def newAnticipatedEvent'' {v} [Preorder v] {M} [Machine CTX M] (ev : AnticipatedEventSpec'' v M) : AnticipatedEvent v M Unit Unit :=
+def newAnticipatedEvent'' {v} [Preorder v] {M} [@Machine CTX M] (ev : AnticipatedEventSpec'' v M) : AnticipatedEvent v M Unit Unit :=
   newAnticipatedEvent ev.toAnticipatedEventSpec
 
 
@@ -166,7 +166,7 @@ def newAnticipatedEvent'' {v} [Preorder v] {M} [Machine CTX M] (ev : Anticipated
 -/
 
 /-- The internal representation of proof obligations for convergent events. -/
-structure _ConvergentEventPO (v) [Preorder v] [WellFoundedLT v] [Machine CTX M] (ev : _Event M α β) (kind : EventKind)
+structure _ConvergentEventPO (v) [Preorder v] [WellFoundedLT v] [@Machine CTX M] (ev : _Event M α β) (kind : EventKind)
           extends _AnticipatedEventPO v ev kind  where
 
   convergence (m : M) (x : α):
@@ -179,12 +179,12 @@ structure _ConvergentEventPO (v) [Preorder v] [WellFoundedLT v] [Machine CTX M] 
 It is an event for machine type `M` with input type `α` and output type `β`.
 The convergence argument is based on the variant type `v` assumed
 to be a well-founded preorder. -/
-structure ConvergentEvent (v) [Preorder v]  [WellFoundedLT v] (M) [Machine CTX M] (α) (β)
+structure ConvergentEvent (v) [Preorder v]  [WellFoundedLT v] (M) [@Machine CTX M] (α) (β)
           extends (_Event M α β)  where
   po : _ConvergentEventPO v to_Event (EventKind.TransDet Convergence.Convergent)
 
 @[simp]
-private def ConvergentEvent_fromOrdinary  {v} [Preorder v] [WellFoundedLT v] {M} [Machine CTX M] (ev : OrdinaryEvent M α β)
+private def ConvergentEvent_fromOrdinary  {v} [Preorder v] [WellFoundedLT v] {M} [@Machine CTX M] (ev : OrdinaryEvent M α β)
   (variant : M → v)
   (Hconv: ∀ (m : M) (x : α),
     Machine.invariant m
@@ -209,7 +209,7 @@ private def ConvergentEvent_fromOrdinary  {v} [Preorder v] [WellFoundedLT v] {M}
  }
 
 @[simp]
-def ConvergentEvent.toOrdinaryEvent [Preorder v] [WellFoundedLT v] [Machine CTX M]
+def ConvergentEvent.toOrdinaryEvent [Preorder v] [WellFoundedLT v] [@Machine CTX M]
   (ev : ConvergentEvent v M α β) : OrdinaryEvent M α β :=
   {
     to_Event := ev.to_Event
@@ -220,7 +220,7 @@ def ConvergentEvent.toOrdinaryEvent [Preorder v] [WellFoundedLT v] [Machine CTX 
 
 /-- The "downgrading" of a convergent event to an anticipated one. -/
 @[simp]
-def ConvergentEvent.toAnticipatedEvent [Preorder v] [WellFoundedLT v] [Machine CTX M]
+def ConvergentEvent.toAnticipatedEvent [Preorder v] [WellFoundedLT v] [@Machine CTX M]
   (ev : ConvergentEvent v M α β) : AnticipatedEvent v M α β :=
   {
     to_Event := ev.to_Event
@@ -238,7 +238,7 @@ with input type `α` and output type `β`. The convergence proof relies
 Note that the guard, action and safety PO of the event must be also
 specified, as in the ordinary case (cf. `OrdinaryEventSpec`).
   -/
-structure ConvergentEventSpec (v) [Preorder v] [WellFoundedLT v] (M) [instM:Machine CTX M] (α) (β)
+structure ConvergentEventSpec (v) [Preorder v] [WellFoundedLT v] (M) [instM:@Machine CTX M] (α) (β)
   extends _Variant v (instM:=instM), EventSpec M α β where
   /-- Proof obligation: the variant is strictly decreasing. -/
   convergence (m : M) (x : α):
@@ -250,11 +250,11 @@ structure ConvergentEventSpec (v) [Preorder v] [WellFoundedLT v] (M) [instM:Mach
 /-- Construction of a convergent deterministic event from a
 `ConvergentEventSpec` specification. -/
 @[simp]
-def newConvergentEvent {v} [Preorder v] [WellFoundedLT v] {M} [Machine CTX M] (ev : ConvergentEventSpec v M α β) : ConvergentEvent v M α β :=
+def newConvergentEvent {v} [Preorder v] [WellFoundedLT v] {M} [@Machine CTX M] (ev : ConvergentEventSpec v M α β) : ConvergentEvent v M α β :=
   ConvergentEvent_fromOrdinary (newEvent ev.toEventSpec) ev.to_Variant.variant ev.convergence
 
 @[simp]
-private def ConvergentEvent_fromAnticipated {v} [Preorder v] [WellFoundedLT v] {M} [Machine CTX M] (ev : AnticipatedEvent v M α β)
+private def ConvergentEvent_fromAnticipated {v} [Preorder v] [WellFoundedLT v] {M} [@Machine CTX M] (ev : AnticipatedEvent v M α β)
     (hconv : (m : M) → (x : α)
     → Machine.invariant m
     → (grd : ev.guard m x)
@@ -272,7 +272,7 @@ private def ConvergentEvent_fromAnticipated {v} [Preorder v] [WellFoundedLT v] {
   }
 
 /-- Variant of `ConvergentEventSpec` with implicit `Unit` output type -/
-structure ConvergentEventSpec' (v) [Preorder v] [WellFoundedLT v] (M) [instM:Machine CTX M] (α)
+structure ConvergentEventSpec' (v) [Preorder v] [WellFoundedLT v] (M) [instM:@Machine CTX M] (α)
   extends _Variant v (instM:=instM), EventSpec' M α where
 
   convergence (m : M) (x : α):
@@ -282,7 +282,7 @@ structure ConvergentEventSpec' (v) [Preorder v] [WellFoundedLT v] (M) [instM:Mac
       variant m' < variant m
 
 @[simp]
-def ConvergentEventSpec'.toConvergentEventSpec {v} [Preorder v] [WellFoundedLT v] {M} [Machine CTX M] (ev : ConvergentEventSpec' v M α) : ConvergentEventSpec v M α Unit :=
+def ConvergentEventSpec'.toConvergentEventSpec {v} [Preorder v] [WellFoundedLT v] {M} [@Machine CTX M] (ev : ConvergentEventSpec' v M α) : ConvergentEventSpec v M α Unit :=
   {
     toEventSpec := ev.toEventSpec
     variant := ev.variant
@@ -291,11 +291,11 @@ def ConvergentEventSpec'.toConvergentEventSpec {v} [Preorder v] [WellFoundedLT v
 
 /-- Variant of `newConvergentEvent` with implicit `Unit` output type -/
 @[simp]
-def newConvergentEvent' {v} [Preorder v] [WellFoundedLT v] {M} [Machine CTX M] (ev : ConvergentEventSpec' v M α ) : ConvergentEvent v M α Unit :=
+def newConvergentEvent' {v} [Preorder v] [WellFoundedLT v] {M} [@Machine CTX M] (ev : ConvergentEventSpec' v M α ) : ConvergentEvent v M α Unit :=
   newConvergentEvent ev.toConvergentEventSpec
 
 /-- Variant of `ConvergentEventSpec` with implicit `Unit` input and output types -/
-structure ConvergentEventSpec'' (v) [Preorder v] [WellFoundedLT v] (M) [instM:Machine CTX M]
+structure ConvergentEventSpec'' (v) [Preorder v] [WellFoundedLT v] (M) [instM:@Machine CTX M]
   extends _Variant v (instM:=instM), EventSpec'' M where
 
   convergence (m : M):
@@ -305,7 +305,7 @@ structure ConvergentEventSpec'' (v) [Preorder v] [WellFoundedLT v] (M) [instM:Ma
       variant m' < variant m
 
 @[simp]
-def ConvergentEventSpec''.toConvergentEventSpec {v} [Preorder v] [WellFoundedLT v] {M} [Machine CTX M] (ev : ConvergentEventSpec'' v M) : ConvergentEventSpec v M Unit Unit :=
+def ConvergentEventSpec''.toConvergentEventSpec {v} [Preorder v] [WellFoundedLT v] {M} [@Machine CTX M] (ev : ConvergentEventSpec'' v M) : ConvergentEventSpec v M Unit Unit :=
   {
     toEventSpec := ev.toEventSpec
     variant := ev.variant
@@ -314,7 +314,7 @@ def ConvergentEventSpec''.toConvergentEventSpec {v} [Preorder v] [WellFoundedLT 
 
 /-- Variant of `newConvergentEvent` with implicit `Unit` input and output types -/
 @[simp]
-def newConvergentEvent'' {v} [Preorder v] [WellFoundedLT v] {M} [Machine CTX M] (ev : ConvergentEventSpec'' v M) : ConvergentEvent v M Unit Unit :=
+def newConvergentEvent'' {v} [Preorder v] [WellFoundedLT v] {M} [@Machine CTX M] (ev : ConvergentEventSpec'' v M) : ConvergentEvent v M Unit Unit :=
   newConvergentEvent ev.toConvergentEventSpec
 
 /-!
@@ -326,7 +326,7 @@ and convergent events (experimental, not documented).
 -/
 
 @[simp]
-def mapAnticipatedEvent [Preorder v] [Machine CTX M] (f : α → β) (ev : AnticipatedEvent v M γ α) : AnticipatedEvent v M γ β :=
+def mapAnticipatedEvent [Preorder v] [@Machine CTX M] (f : α → β) (ev : AnticipatedEvent v M γ α) : AnticipatedEvent v M γ β :=
   newAnticipatedEvent {
     guard := ev.guard
     action := fun m x grd => let (y, m') := ev.action m x grd
@@ -336,15 +336,15 @@ def mapAnticipatedEvent [Preorder v] [Machine CTX M] (f : α → β) (ev : Antic
     nonIncreasing := ev.po.nonIncreasing
   }
 
-instance [Preorder v] [Machine CTX M] : Functor (AnticipatedEvent v M γ) where
+instance [Preorder v] [@Machine CTX M] : Functor (AnticipatedEvent v M γ) where
   map := mapAnticipatedEvent
 
-instance [Preorder v] [Machine CTX M] : LawfulFunctor (AnticipatedEvent v M γ) where
+instance [Preorder v] [@Machine CTX M] : LawfulFunctor (AnticipatedEvent v M γ) where
   map_const := rfl
   id_map := by intros ; rfl
   comp_map := by intros ; rfl
 
-def mapConvergentEvent [Preorder v] [WellFoundedLT v] [Machine CTX M] (f : α → β) (ev : ConvergentEvent v M γ α) : ConvergentEvent v M γ β :=
+def mapConvergentEvent [Preorder v] [WellFoundedLT v] [@Machine CTX M] (f : α → β) (ev : ConvergentEvent v M γ α) : ConvergentEvent v M γ β :=
   newConvergentEvent {
     guard := ev.guard
     action := fun m x grd => let (y, m') := ev.action m x grd
@@ -354,26 +354,26 @@ def mapConvergentEvent [Preorder v] [WellFoundedLT v] [Machine CTX M] (f : α �
     convergence := ev.po.convergence
   }
 
-instance [Preorder v] [WellFoundedLT v] [Machine CTX M] : Functor (ConvergentEvent v M γ) where
+instance [Preorder v] [WellFoundedLT v] [@Machine CTX M] : Functor (ConvergentEvent v M γ) where
   map := mapConvergentEvent
 
-instance [Preorder v] [WellFoundedLT v] [Machine CTX M] : LawfulFunctor (ConvergentEvent v M γ) where
+instance [Preorder v] [WellFoundedLT v] [@Machine CTX M] : LawfulFunctor (ConvergentEvent v M γ) where
   map_const := rfl
   id_map := by intros ; rfl
   comp_map := by intros ; rfl
 
 /- Contravariant functor -/
 
-abbrev CoAnticipatedEvent (v) [Preorder v] (M) [Machine CTX M] (α) (β) :=
+abbrev CoAnticipatedEvent (v) [Preorder v] (M) [@Machine CTX M] (α) (β) :=
    AnticipatedEvent v M β α
 
 @[simp]
-def AnticipatedEvent_from_CoAnticipatedEvent [Preorder v] [Machine CTX M] (ev : CoAnticipatedEvent v M α β) : AnticipatedEvent v M β α := ev
+def AnticipatedEvent_from_CoAnticipatedEvent [Preorder v] [@Machine CTX M] (ev : CoAnticipatedEvent v M α β) : AnticipatedEvent v M β α := ev
 
 @[simp]
-def CoAnticipatedEvent_from_AnticipatedEvent [Preorder v] [Machine CTX M] (ev : AnticipatedEvent v M α β) : CoAnticipatedEvent v M β α := ev
+def CoAnticipatedEvent_from_AnticipatedEvent [Preorder v] [@Machine CTX M] (ev : AnticipatedEvent v M α β) : CoAnticipatedEvent v M β α := ev
 
-instance [Preorder v] [Machine CTX M]: ContravariantFunctor (CoAnticipatedEvent v M γ) where
+instance [Preorder v] [@Machine CTX M]: ContravariantFunctor (CoAnticipatedEvent v M γ) where
   contramap {α β} (f : β → α) (ev : CoAnticipatedEvent v M γ α) :=
   let event := let ev' := coEvent_from_Event ev.to_Event
              let ev'' := ContravariantFunctor.contramap f ev'
@@ -395,20 +395,20 @@ instance [Preorder v] [Machine CTX M]: ContravariantFunctor (CoAnticipatedEvent 
     }
   }
 
-instance [Preorder v] [Machine CTX M] : LawfullContravariantFunctor (CoAnticipatedEvent v M α) where
+instance [Preorder v] [@Machine CTX M] : LawfullContravariantFunctor (CoAnticipatedEvent v M α) where
   cmap_id _ := by rfl
   cmap_comp _ _ := by rfl
 
-abbrev CoConvergentEvent (v) [Preorder v] [WellFoundedLT v] (M) [Machine CTX M] (α) (β) :=
+abbrev CoConvergentEvent (v) [Preorder v] [WellFoundedLT v] (M) [@Machine CTX M] (α) (β) :=
    ConvergentEvent v M β α
 
 @[simp]
-def ConvergentEvent_from_CoConvergentEvent [Preorder v] [WellFoundedLT v] [Machine CTX M] (ev : CoConvergentEvent v M α β) : ConvergentEvent v M β α := ev
+def ConvergentEvent_from_CoConvergentEvent [Preorder v] [WellFoundedLT v] [@Machine CTX M] (ev : CoConvergentEvent v M α β) : ConvergentEvent v M β α := ev
 
 @[simp]
-def CoConvergentEvent_from_ConvergentEvent [Preorder v] [WellFoundedLT v] [Machine CTX M] (ev : ConvergentEvent v M α β) : CoConvergentEvent v M β α := ev
+def CoConvergentEvent_from_ConvergentEvent [Preorder v] [WellFoundedLT v] [@Machine CTX M] (ev : ConvergentEvent v M α β) : CoConvergentEvent v M β α := ev
 
-instance [Preorder v] [WellFoundedLT v] [Machine CTX M]: ContravariantFunctor (CoConvergentEvent v M γ) where
+instance [Preorder v] [WellFoundedLT v] [@Machine CTX M]: ContravariantFunctor (CoConvergentEvent v M γ) where
   contramap {α β} (f : β → α) (ev : CoConvergentEvent v M γ α) :=
   let event := let ev' := coEvent_from_Event ev.to_Event
              let ev'' := ContravariantFunctor.contramap f ev'
@@ -430,13 +430,13 @@ instance [Preorder v] [WellFoundedLT v] [Machine CTX M]: ContravariantFunctor (C
     }
   }
 
-instance [Preorder v] [WellFoundedLT v] [Machine CTX M] : LawfullContravariantFunctor (CoConvergentEvent v M α) where
+instance [Preorder v] [WellFoundedLT v] [@Machine CTX M] : LawfullContravariantFunctor (CoConvergentEvent v M α) where
   cmap_id _ := by rfl
   cmap_comp _ _ := by rfl
 
 /- Profunctor -/
 
-instance [Preorder v] [Machine CTX M] : Profunctor (AnticipatedEvent v M) where
+instance [Preorder v] [@Machine CTX M] : Profunctor (AnticipatedEvent v M) where
   dimap {α β} {γ δ} (f : β → α) (g : γ → δ) (ev : AnticipatedEvent v M α γ) : AnticipatedEvent v M β δ :=
     let event := Profunctor.dimap f g ev.to_Event
     {
@@ -467,11 +467,11 @@ instance [Preorder v] [Machine CTX M] : Profunctor (AnticipatedEvent v M) where
       }
     }
 
-instance [Preorder v] [Machine CTX M] : LawfulProfunctor (AnticipatedEvent v M) where
+instance [Preorder v] [@Machine CTX M] : LawfulProfunctor (AnticipatedEvent v M) where
   dimap_id := rfl
   dimap_comp _ _ _ _ := rfl
 
-instance [Preorder v] [Machine CTX M] : StrongProfunctor (AnticipatedEvent v M) where
+instance [Preorder v] [@Machine CTX M] : StrongProfunctor (AnticipatedEvent v M) where
   first' {α β γ} (ev : AnticipatedEvent v M α β): AnticipatedEvent v M (α × γ) (β × γ) :=
     let event := StrongProfunctor.first' ev.to_Event
     {
@@ -491,10 +491,10 @@ instance [Preorder v] [Machine CTX M] : StrongProfunctor (AnticipatedEvent v M) 
       }
     }
 
-instance [Preorder v] [Machine CTX M] : LawfulStrongProfunctor (AnticipatedEvent v M) where
+instance [Preorder v] [@Machine CTX M] : LawfulStrongProfunctor (AnticipatedEvent v M) where
   -- XXX : at some point the laws should be demonstrated
 
-instance [Preorder v] [WellFoundedLT v] [Machine CTX M] : Profunctor (ConvergentEvent v M) where
+instance [Preorder v] [WellFoundedLT v] [@Machine CTX M] : Profunctor (ConvergentEvent v M) where
   dimap {α β} {γ δ} (f : β → α) (g : γ → δ) (ev : ConvergentEvent v M α γ) : ConvergentEvent v M β δ :=
     let event := Profunctor.dimap f g ev.to_Event
     {
@@ -535,11 +535,11 @@ instance [Preorder v] [WellFoundedLT v] [Machine CTX M] : Profunctor (Convergent
       }
     }
 
-instance [Preorder v] [WellFoundedLT v] [Machine CTX M] : LawfulProfunctor (ConvergentEvent v M) where
+instance [Preorder v] [WellFoundedLT v] [@Machine CTX M] : LawfulProfunctor (ConvergentEvent v M) where
   dimap_id := rfl
   dimap_comp _ _ _ _ := rfl
 
-instance [Preorder v] [WellFoundedLT v] [Machine CTX M] : StrongProfunctor (ConvergentEvent v M) where
+instance [Preorder v] [WellFoundedLT v] [@Machine CTX M] : StrongProfunctor (ConvergentEvent v M) where
   first' {α β γ} (ev : ConvergentEvent v M α β): ConvergentEvent v M (α × γ) (β × γ) :=
     let event := StrongProfunctor.first' ev.to_Event
     {
@@ -566,7 +566,7 @@ instance [Preorder v] [WellFoundedLT v] [Machine CTX M] : StrongProfunctor (Conv
       }
     }
 
-instance [Preorder v] [WellFoundedLT v] [Machine CTX M] : LawfulStrongProfunctor (ConvergentEvent v M) where
+instance [Preorder v] [WellFoundedLT v] [@Machine CTX M] : LawfulStrongProfunctor (ConvergentEvent v M) where
   -- XXX : at some point the laws should be demonstrated
 
 /-

--- a/LeanMachines/Event/Ordinary.lean
+++ b/LeanMachines/Event/Ordinary.lean
@@ -19,7 +19,7 @@ is not demonstrated anticipated or convergent
 
 /-- The internal representation of proof obligations for ordinary
 deterministic events. -/
-structure _EventPO [Machine CTX M] (ev : _Event M α β) (kind : EventKind) where
+structure _EventPO [@Machine CTX M] (ev : _Event M α β) (kind : EventKind) where
   safety (m : M) (x : α):
     Machine.invariant m
     → (grd : ev.guard m x)
@@ -27,10 +27,10 @@ structure _EventPO [Machine CTX M] (ev : _Event M α β) (kind : EventKind) wher
 
 /-- The type of deterministic events without convergence properties.
 It is an event for machine type `M` with input type `α` and output type `β` -/
-structure OrdinaryEvent (M) [Machine CTX M] (α) (β) extends _Event M α β where
+structure OrdinaryEvent (M) [@Machine CTX M] (α) (β) extends _Event M α β where
   po : _EventPO to_Event  (EventKind.TransDet Convergence.Ordinary)
 
-theorem OrdinaryEvent.ext [Machine CTX M] (ev₁ : OrdinaryEvent M α β) (ev₂ : OrdinaryEvent M α β):
+theorem OrdinaryEvent.ext [@Machine CTX M] (ev₁ : OrdinaryEvent M α β) (ev₂ : OrdinaryEvent M α β):
   ev₁.to_Event = ev₂.to_Event
   → ev₁ = ev₂ :=
 by
@@ -38,7 +38,7 @@ by
 
 /-- The specification of a deterministic, ordinary event for machine `M`
 with input type `α` and output type `β`. . -/
-structure EventSpec (M) [Machine CTX M] (α) (β) where
+structure EventSpec (M) [@Machine CTX M] (α) (β) where
   /-- The guard property of the event, in machine state `m` with input `x`. -/
   guard (m : M) (x : α) : Prop := True
   /-- The (deterministic) action of the event, with
@@ -56,7 +56,7 @@ structure EventSpec (M) [Machine CTX M] (α) (β) where
     → Machine.invariant (action m x grd).2
 
 @[simp]
-def _Event.toEventSpec [Machine CTX M]
+def _Event.toEventSpec [@Machine CTX M]
   (ev : _Event M α β)
   (Hsafe : (m : M) → (x : α) →  Machine.invariant m
                            → (grd : ev.guard m x)
@@ -67,7 +67,7 @@ def _Event.toEventSpec [Machine CTX M]
   }
 
 @[simp]
-def EventSpec.to_Event [Machine CTX M] (ev : EventSpec M α β) : _Event M α β :=
+def EventSpec.to_Event [@Machine CTX M] (ev : EventSpec M α β) : _Event M α β :=
   { guard := ev.guard
     action := ev.action
   }
@@ -75,7 +75,7 @@ def EventSpec.to_Event [Machine CTX M] (ev : EventSpec M α β) : _Event M α β
 /-- Construction of an ordinary deterministic event from a
 `EventSpec` specification. -/
 @[simp]
-def newEvent {M} [Machine CTX M] (ev : EventSpec M α β) : OrdinaryEvent M α β :=
+def newEvent {M} [@Machine CTX M] (ev : EventSpec M α β) : OrdinaryEvent M α β :=
   { to_Event := ev.to_Event
     po := {
       safety := fun m x => by
@@ -85,7 +85,7 @@ def newEvent {M} [Machine CTX M] (ev : EventSpec M α β) : OrdinaryEvent M α �
   }
 
 /-- Variant of `EventSpec` with implicit `Unit` output type -/
-structure EventSpec' (M) [Machine CTX M] (α) where
+structure EventSpec' (M) [@Machine CTX M] (α) where
   guard (m : M) (x : α) : Prop := True
   action (m : M) (x : α) (grd : guard m x): M
   safety (m : M) (x : α) :
@@ -94,7 +94,7 @@ structure EventSpec' (M) [Machine CTX M] (α) where
     → Machine.invariant (action m x grd)
 
 @[simp]
-def EventSpec'.toEventSpec [Machine CTX M] (ev : EventSpec' M α) : EventSpec M α Unit :=
+def EventSpec'.toEventSpec [@Machine CTX M] (ev : EventSpec' M α) : EventSpec M α Unit :=
   {
     guard := ev.guard
     action := fun m x grd => ((), ev.action m x grd)
@@ -103,11 +103,11 @@ def EventSpec'.toEventSpec [Machine CTX M] (ev : EventSpec' M α) : EventSpec M 
 
 /-- Variant of `newEvent` with implicit `Unit` output type -/
 @[simp]
-def newEvent' {M} [Machine CTX M] (ev : EventSpec' M α) : OrdinaryEvent M α Unit :=
+def newEvent' {M} [@Machine CTX M] (ev : EventSpec' M α) : OrdinaryEvent M α Unit :=
   newEvent ev.toEventSpec
 
 /-- Variant of `EventSpec` with implicit `Unit` input and output types -/
-structure EventSpec'' (M) [Machine CTX M] where
+structure EventSpec'' (M) [@Machine CTX M] where
   guard (m : M) : Prop := True
   action (m : M) (grd : guard m): M
   safety (m : M) :
@@ -116,7 +116,7 @@ structure EventSpec'' (M) [Machine CTX M] where
     → Machine.invariant (action m grd)
 
 @[simp]
-def EventSpec''.toEventSpec [Machine CTX M] (ev : EventSpec'' M) : EventSpec M Unit Unit :=
+def EventSpec''.toEventSpec [@Machine CTX M] (ev : EventSpec'' M) : EventSpec M Unit Unit :=
   {
     guard := fun m () => ev.guard m
     action := fun m () grd => ((), ev.action m grd)
@@ -125,10 +125,10 @@ def EventSpec''.toEventSpec [Machine CTX M] (ev : EventSpec'' M) : EventSpec M U
 
 /-- Variant of `newEvent` with implicit `Unit` input and output types -/
 @[simp]
-def newEvent'' {M} [Machine CTX M] (ev : EventSpec'' M) : OrdinaryEvent M Unit Unit :=
+def newEvent'' {M} [@Machine CTX M] (ev : EventSpec'' M) : OrdinaryEvent M Unit Unit :=
   newEvent ev.toEventSpec
 
-def skipEvent (M) [Machine CTX M] (α) : OrdinaryEvent M α α :=
+def skipEvent (M) [@Machine CTX M] (α) : OrdinaryEvent M α α :=
   newEvent ((skip_Event M α).toEventSpec
                                  (by intros ; simp [skip_Event] ; assumption))
 
@@ -142,7 +142,7 @@ are ordinary deterministic events with the *default* state as a pre-state.
  -/
 
 /-- The internal representation of proof obligations for initialization events. -/
-structure _InitEventPO [Machine CTX M] (ev : _InitEvent M α β) (kind : EventKind) where
+structure _InitEventPO [@Machine CTX M] (ev : _InitEvent M α β) (kind : EventKind) where
   safety (x : α):
     (grd : ev.guard x)
     → Machine.invariant (ev.init x grd).snd
@@ -150,12 +150,12 @@ structure _InitEventPO [Machine CTX M] (ev : _InitEvent M α β) (kind : EventKi
 
 /-- Type type of deterministic initialization events.
 It is an event for machine type `M` with input type `α` and output type `β` -/
-structure InitEvent (M) [Machine CTX M] (α) (β) extends _InitEvent M α β where
+structure InitEvent (M) [@Machine CTX M] (α) (β) extends _InitEvent M α β where
   po : _InitEventPO to_InitEvent EventKind.InitDet
 
 /-- The specification of a deterministic ordinary event for machine `M`
 with input type `α` and output type `β`. . -/
-structure InitEventSpec (M) [Machine CTX M] (α) (β) where
+structure InitEventSpec (M) [@Machine CTX M] (α) (β) where
   /-- The guard property of the event, an initialization with input `x`. -/
   guard (x : α) : Prop := True
   /-- The (deterministic) action of the event, with input `x`, building a pair
@@ -167,7 +167,7 @@ structure InitEventSpec (M) [Machine CTX M] (α) (β) where
     → Machine.invariant (init x grd).2
 
 @[simp]
-def InitEventSpec.to_InitEvent [Machine CTX M] (ev : InitEventSpec M α β) : _InitEvent M α β :=
+def InitEventSpec.to_InitEvent [@Machine CTX M] (ev : InitEventSpec M α β) : _InitEvent M α β :=
   {
     guard := ev.guard
     init := ev.init
@@ -176,7 +176,7 @@ def InitEventSpec.to_InitEvent [Machine CTX M] (ev : InitEventSpec M α β) : _I
 /-- Construction of a deterministic initialization event from a
 `InitEventSpec` specification. -/
 @[simp]
-def newInitEvent {M} [Machine CTX M] (ev : InitEventSpec M α β) : InitEvent M α β :=
+def newInitEvent {M} [@Machine CTX M] (ev : InitEventSpec M α β) : InitEvent M α β :=
   {
     to_InitEvent := ev.to_InitEvent
     po := {
@@ -188,7 +188,7 @@ def newInitEvent {M} [Machine CTX M] (ev : InitEventSpec M α β) : InitEvent M 
   }
 
 /-- Variant of `InitEventSpec` with implicit `Unit` output type -/
-structure InitEventSpec' (M) [Machine CTX M] (α) where
+structure InitEventSpec' (M) [@Machine CTX M] (α) where
   guard (x : α) : Prop := True
   init (x : α) (grd : guard x): M
   safety (x : α) :
@@ -196,7 +196,7 @@ structure InitEventSpec' (M) [Machine CTX M] (α) where
     → Machine.invariant (init x grd)
 
 @[simp]
-def InitEventSpec'.toInitEventSpec [Machine CTX M] (ev : InitEventSpec' M α) : InitEventSpec M α Unit :=
+def InitEventSpec'.toInitEventSpec [@Machine CTX M] (ev : InitEventSpec' M α) : InitEventSpec M α Unit :=
   {
     guard := ev.guard
     init := fun x grd => ((), ev.init x grd)
@@ -205,11 +205,11 @@ def InitEventSpec'.toInitEventSpec [Machine CTX M] (ev : InitEventSpec' M α) : 
 
 /-- Variant of `newInitEvent` with implicit `Unit` output type -/
 @[simp]
-def newInitEvent' {M} [Machine CTX M] (ev : InitEventSpec' M α) : InitEvent M α Unit :=
+def newInitEvent' {M} [@Machine CTX M] (ev : InitEventSpec' M α) : InitEvent M α Unit :=
   newInitEvent ev.toInitEventSpec
 
 /-- Variant of `InitEventSpec` with implicit `Unit` input and output types -/
-structure InitEventSpec'' (M) [Machine CTX M] where
+structure InitEventSpec'' (M) [@Machine CTX M] where
   guard : Prop := True
   init (grd : guard) : M
   safety :
@@ -217,7 +217,7 @@ structure InitEventSpec'' (M) [Machine CTX M] where
     → Machine.invariant (init grd)
 
 @[simp]
-def InitEventSpec''.toInitEventSpec [Machine CTX M] (ev : InitEventSpec'' M) : InitEventSpec M Unit Unit :=
+def InitEventSpec''.toInitEventSpec [@Machine CTX M] (ev : InitEventSpec'' M) : InitEventSpec M Unit Unit :=
   {
     guard := fun () => ev.guard
     init := fun () grd => ((), ev.init grd)
@@ -226,7 +226,7 @@ def InitEventSpec''.toInitEventSpec [Machine CTX M] (ev : InitEventSpec'' M) : I
 
 /-- Variant of `newInitEvent` with implicit `Unit` input and output types -/
 @[simp]
-def newInitEvent'' {M} [Machine CTX M] (ev : InitEventSpec'' M) : InitEvent M Unit Unit :=
+def newInitEvent'' {M} [@Machine CTX M] (ev : InitEventSpec'' M) : InitEvent M Unit Unit :=
   newInitEvent ev.toInitEventSpec
 
 /-!
@@ -243,11 +243,11 @@ This part is rather experimental and is thus not fully documented yet.
 /- Functor -/
 
 @[simp]
-def funEvent (M) [Machine CTX M] (f : α → β) : OrdinaryEvent M α β :=
+def funEvent (M) [@Machine CTX M] (f : α → β) : OrdinaryEvent M α β :=
   newEvent ((fun_Event M f).toEventSpec
                                  (fun m x Hinv _ => by simp [fun_Event] ; assumption))
 
-def mapEvent [Machine CTX M] (f : α → β) (ev : OrdinaryEvent M γ α) : OrdinaryEvent M γ β :=
+def mapEvent [@Machine CTX M] (f : α → β) (ev : OrdinaryEvent M γ α) : OrdinaryEvent M γ β :=
   {
     to_Event := Functor.map f ev.to_Event
     po := { safety := fun m x => by intros Hinv Hgrd
@@ -256,10 +256,10 @@ def mapEvent [Machine CTX M] (f : α → β) (ev : OrdinaryEvent M γ α) : Ordi
   }
 }
 
-instance [Machine CTX M] : Functor (OrdinaryEvent M γ) where
+instance [@Machine CTX M] : Functor (OrdinaryEvent M γ) where
   map := mapEvent
 
-instance [Machine CTX M] : LawfulFunctor (OrdinaryEvent M γ) where
+instance [@Machine CTX M] : LawfulFunctor (OrdinaryEvent M γ) where
   map_const := rfl
   id_map := by intros ; rfl
   comp_map := by intros ; rfl
@@ -267,7 +267,7 @@ instance [Machine CTX M] : LawfulFunctor (OrdinaryEvent M γ) where
 /- Applicative Functor -/
 
 @[simp]
-def pureEvent [Machine CTX M] (y : α) : OrdinaryEvent M γ α :=
+def pureEvent [@Machine CTX M] (y : α) : OrdinaryEvent M γ α :=
   {
     to_Event := pure y
     po := {
@@ -275,10 +275,10 @@ def pureEvent [Machine CTX M] (y : α) : OrdinaryEvent M γ α :=
     }
   }
 
-instance [Machine CTX M]: Pure (OrdinaryEvent M γ) where
+instance [@Machine CTX M]: Pure (OrdinaryEvent M γ) where
   pure := pureEvent
 
-def applyEvent [Machine CTX M] ( ef : OrdinaryEvent M γ (α → β)) (ev : OrdinaryEvent M γ α) : OrdinaryEvent M γ β :=
+def applyEvent [@Machine CTX M] ( ef : OrdinaryEvent M γ (α → β)) (ev : OrdinaryEvent M γ α) : OrdinaryEvent M γ β :=
   let event := ef.to_Event <*> ev.to_Event
   {
     guard := event.guard
@@ -292,10 +292,10 @@ def applyEvent [Machine CTX M] ( ef : OrdinaryEvent M γ (α → β)) (ev : Ordi
     }
   }
 
-instance [Machine CTX M]: Applicative (OrdinaryEvent M γ) where
+instance [@Machine CTX M]: Applicative (OrdinaryEvent M γ) where
   seq ef ev := applyEvent ef (ev ())
 
-instance [Machine CTX M]: LawfulApplicative (OrdinaryEvent M γ) where
+instance [@Machine CTX M]: LawfulApplicative (OrdinaryEvent M γ) where
   map_const := by intros ; rfl
   id_map := by intros ; rfl
   seqLeft_eq := by intros ; rfl
@@ -317,7 +317,7 @@ instance [Machine CTX M]: LawfulApplicative (OrdinaryEvent M γ) where
     apply OrdinaryEvent.ext
     apply seq_assoc
 
-def bindEvent [Machine CTX M] (ev : OrdinaryEvent M γ α) (f : α → OrdinaryEvent M γ β) : OrdinaryEvent M γ β :=
+def bindEvent [@Machine CTX M] (ev : OrdinaryEvent M γ α) (f : α → OrdinaryEvent M γ β) : OrdinaryEvent M γ β :=
   let event := ev.to_Event >>= (fun x => (f x).to_Event)
   {
     guard := event.guard
@@ -335,15 +335,15 @@ def bindEvent [Machine CTX M] (ev : OrdinaryEvent M γ α) (f : α → OrdinaryE
     }
   }
 
-instance [Machine CTX M]: Monad (OrdinaryEvent M γ) where
+instance [@Machine CTX M]: Monad (OrdinaryEvent M γ) where
   bind := bindEvent
 
-theorem OrdinaryEvent_liftBind [Machine CTX M] (ev : OrdinaryEvent M γ α) (f : α → OrdinaryEvent M γ β):
+theorem OrdinaryEvent_liftBind [@Machine CTX M] (ev : OrdinaryEvent M γ α) (f : α → OrdinaryEvent M γ β):
   (ev >>= f).to_Event = (ev.to_Event >>= fun x => (f x).to_Event) :=
 by
   simp [bind, bindEvent]
 
-instance [Machine CTX M]: LawfulMonad (OrdinaryEvent M γ) where
+instance [@Machine CTX M]: LawfulMonad (OrdinaryEvent M γ) where
   bind_pure_comp := by
     intros
     apply OrdinaryEvent.ext
@@ -364,7 +364,7 @@ instance [Machine CTX M]: LawfulMonad (OrdinaryEvent M γ) where
 
 /- Category and Arrow -/
 
-instance [Machine CTX M]: Category (OrdinaryEvent M) where
+instance [@Machine CTX M]: Category (OrdinaryEvent M) where
   id := funEvent M id
 
   comp {α β γ} (ev₂ : OrdinaryEvent M β γ) (ev₁ : OrdinaryEvent M α β) : OrdinaryEvent M α γ :=
@@ -381,7 +381,7 @@ instance [Machine CTX M]: Category (OrdinaryEvent M) where
       }
     }
 
-instance [Machine CTX M]: LawfulCategory (OrdinaryEvent M) where
+instance [@Machine CTX M]: LawfulCategory (OrdinaryEvent M) where
   id_right _ := by
     apply OrdinaryEvent.ext
     apply LawfulCategory.id_right
@@ -395,7 +395,7 @@ instance [Machine CTX M]: LawfulCategory (OrdinaryEvent M) where
     apply LawfulCategory.id_assoc
 
 @[simp]
-def OrdinaryEvent_Arrow_first [Machine CTX M] (ev : OrdinaryEvent M α β) : OrdinaryEvent M (α × γ) (β × γ) :=
+def OrdinaryEvent_Arrow_first [@Machine CTX M] (ev : OrdinaryEvent M α β) : OrdinaryEvent M (α × γ) (β × γ) :=
   let event := Arrow.first ev.to_Event
   {
     guard := event.guard
@@ -407,7 +407,7 @@ def OrdinaryEvent_Arrow_first [Machine CTX M] (ev : OrdinaryEvent M α β) : Ord
     }
   }
 
-instance [Machine CTX M]: Arrow (OrdinaryEvent M) where
+instance [@Machine CTX M]: Arrow (OrdinaryEvent M) where
   arrow {α β} (f : α → β) := {
     to_Event := Arrow.arrow f
     po := {
@@ -427,24 +427,24 @@ instance [Machine CTX M]: Arrow (OrdinaryEvent M) where
   }
 
 
-theorem OrdinaryEvent_lift_arrow [Machine CTX M] (f : α → β):
+theorem OrdinaryEvent_lift_arrow [@Machine CTX M] (f : α → β):
   (instArrowOrdinaryEvent.arrow f).to_Event = (instArrow_Event (M:=M)).arrow f :=
 by
   simp [Arrow.arrow]
 
-theorem OrdinaryEvent_lift_split [Machine CTX M] {α α' β β'} (ev₁ : OrdinaryEvent M α β) (ev₂ : OrdinaryEvent M α' β'):
+theorem OrdinaryEvent_lift_split [@Machine CTX M] {α α' β β'} (ev₁ : OrdinaryEvent M α β) (ev₂ : OrdinaryEvent M α' β'):
   (instArrowOrdinaryEvent.split ev₁ ev₂).to_Event
   = (instArrow_Event (M:=M)).split ev₁.to_Event ev₂.to_Event :=
 by
   simp [Arrow.split, Arrow.first]
 
-theorem OrdinaryEvent_lift_first [Machine CTX M] {α β} (ev : OrdinaryEvent M α β):
+theorem OrdinaryEvent_lift_first [@Machine CTX M] {α β} (ev : OrdinaryEvent M α β):
   (instArrowOrdinaryEvent.first ev (γ:=γ)).to_Event
   = (instArrow_Event (M:=M)).first (ev.to_Event) :=
 by
   simp [Arrow.first]
 
-instance [Machine CTX M]: LawfulArrow (OrdinaryEvent M) where
+instance [@Machine CTX M]: LawfulArrow (OrdinaryEvent M) where
   arrow_id := by simp [Arrow.arrow]
   arrow_ext {α β γ} f := by
     apply OrdinaryEvent.ext
@@ -468,17 +468,17 @@ instance [Machine CTX M]: LawfulArrow (OrdinaryEvent M) where
 
 /- Contravariant functor -/
 
-abbrev CoEvent (M) [Machine CTX M] (α) (β) :=
+abbrev CoEvent (M) [@Machine CTX M] (α) (β) :=
    OrdinaryEvent M β α
 
 @[simp]
-def OrdinaryEvent_from_CoEvent [Machine CTX M] (ev : CoEvent M α β) : OrdinaryEvent M β α := ev
+def OrdinaryEvent_from_CoEvent [@Machine CTX M] (ev : CoEvent M α β) : OrdinaryEvent M β α := ev
 
 @[simp]
-def CoEvent_from_OrdinaryEvent [Machine CTX M] (ev : OrdinaryEvent M α β) : CoEvent M β α := ev
+def CoEvent_from_OrdinaryEvent [@Machine CTX M] (ev : OrdinaryEvent M α β) : CoEvent M β α := ev
 
 
-instance [Machine CTX M]: ContravariantFunctor (CoEvent M γ) where
+instance [@Machine CTX M]: ContravariantFunctor (CoEvent M γ) where
   contramap {α β} (f : β → α) (ev : CoEvent M γ α) :=
   let event := let ev' := coEvent_from_Event ev.to_Event
              let ev'' := ContravariantFunctor.contramap f ev'
@@ -494,13 +494,13 @@ instance [Machine CTX M]: ContravariantFunctor (CoEvent M γ) where
     }
   }
 
-instance [Machine CTX M] : LawfullContravariantFunctor (CoEvent M α) where
+instance [@Machine CTX M] : LawfullContravariantFunctor (CoEvent M α) where
   cmap_id _ := by rfl
   cmap_comp _ _ := by rfl
 
 /- Profunctor -/
 
-instance [Machine CTX M] : Profunctor (OrdinaryEvent M) where
+instance [@Machine CTX M] : Profunctor (OrdinaryEvent M) where
   dimap {α β} {γ δ} (f : β → α) (g : γ → δ) (ev : OrdinaryEvent M α γ) : OrdinaryEvent M β δ :=
     let event := Profunctor.dimap f g ev.to_Event
     {
@@ -519,11 +519,11 @@ instance [Machine CTX M] : Profunctor (OrdinaryEvent M) where
       }
     }
 
-instance [Machine CTX M] : LawfulProfunctor (OrdinaryEvent M) where
+instance [@Machine CTX M] : LawfulProfunctor (OrdinaryEvent M) where
   dimap_id := rfl
   dimap_comp _ _ _ _ := rfl
 
-instance [Machine CTX M] : StrongProfunctor (OrdinaryEvent M) where
+instance [@Machine CTX M] : StrongProfunctor (OrdinaryEvent M) where
   first' {α β γ} (ev : OrdinaryEvent M α β): OrdinaryEvent M (α × γ) (β × γ) :=
     let event := StrongProfunctor.first' ev.to_Event
     {
@@ -536,4 +536,4 @@ instance [Machine CTX M] : StrongProfunctor (OrdinaryEvent M) where
       }
     }
 
-instance [Machine CTX M] : LawfulStrongProfunctor (OrdinaryEvent M) where
+instance [@Machine CTX M] : LawfulStrongProfunctor (OrdinaryEvent M) where

--- a/LeanMachines/NonDet/Basic.lean
+++ b/LeanMachines/NonDet/Basic.lean
@@ -20,12 +20,12 @@ with: `M` the machine type,
 This extends `_EventRoot` with a notion of (non-deterministic/relational) effect.
 .-/
 @[ext]
-structure _NDEvent (M) [Machine CTX M] (α β : Type) where
+structure _NDEvent (M) [@Machine CTX M] (α β : Type) where
   guard (m : M) (x : α) : Prop := True
   effect (m : M) (x : α) (grd : guard m x) (eff : β × M): Prop
 
 @[simp]
-def _Event.to_NDEvent [Machine CTX M] (ev : _Event M α β) : _NDEvent M α β :=
+def _Event.to_NDEvent [@Machine CTX M] (ev : _Event M α β) : _NDEvent M α β :=
 {
   guard := ev.guard
   effect := fun m x grd (x'', m'') => let (x', m') := ev.action m x grd
@@ -34,13 +34,13 @@ def _Event.to_NDEvent [Machine CTX M] (ev : _Event M α β) : _NDEvent M α β :
 
 /- XXX : does this axiom breaks something ?
          (I don't think it's provable because of HEq) -/
-axiom _Effect_ext_ax {CTX} {M} [Machine CTX M] {α β} (ev₁ ev₂: _NDEvent M α β):
+axiom _Effect_ext_ax {CTX} {M} [@Machine CTX M] {α β} (ev₁ ev₂: _NDEvent M α β):
    (∀ m x, ev₁.guard m x = ev₂.guard m x
           ∧ ∀ y m' grd₁ grd₂,
              ev₁.effect m x grd₁ (y, m') ↔ ev₂.effect m x grd₂ (y, m'))
    → HEq ev₁.effect ev₂.effect
 
-theorem _NDEvent.ext' {CTX} {M} [Machine CTX M] {α β} (ev₁ ev₂: _NDEvent M α β):
+theorem _NDEvent.ext' {CTX} {M} [@Machine CTX M] {α β} (ev₁ ev₂: _NDEvent M α β):
   (∀ m x, ev₁.guard m x = ev₂.guard m x
           ∧ ∀ y m' grd₁ grd₂, ev₁.effect m x grd₁ (y, m') ↔ ev₂.effect m x grd₂ (y, m'))
   → ev₁ = ev₂ :=
@@ -65,12 +65,12 @@ by
 with: `M` the machine type,
 `α` the input type, and `β` the output type of the event
 .-/
-structure _InitNDEvent (M) [Machine CTX M] (α) (β : Type) where
+structure _InitNDEvent (M) [@Machine CTX M] (α) (β : Type) where
   guard: α → Prop
   init (x : α) (grd : guard x) (eff: β × M) : Prop
 
 @[simp]
-def _InitEvent.to_InitNDEvent [Machine CTX M] (ev : _InitEvent M α β) : _InitNDEvent M α β :=
+def _InitEvent.to_InitNDEvent [@Machine CTX M] (ev : _InitEvent M α β) : _InitNDEvent M α β :=
 {
   guard := ev.guard
   init := fun x grd (x'', m'') => let (x', m') := ev.init x grd
@@ -78,14 +78,14 @@ def _InitEvent.to_InitNDEvent [Machine CTX M] (ev : _InitEvent M α β) : _InitN
 }
 
 @[simp]
-def _InitNDEvent.to_NDEvent [Machine CTX M] (ev : _InitNDEvent M α β) : _NDEvent M α β :=
+def _InitNDEvent.to_NDEvent [@Machine CTX M] (ev : _InitNDEvent M α β) : _NDEvent M α β :=
 {
   guard := fun m x => m = default ∧ ev.guard x
   effect := fun _ x grd (y, m') => ev.init x grd.2 (y, m')
 }
 
 @[simp]
-def skip_NDEvent [Machine CTX M] : _NDEvent M α β :=
+def skip_NDEvent [@Machine CTX M] : _NDEvent M α β :=
   {
     effect := fun m _ _ (_, m') => m' = m
   }
@@ -98,7 +98,7 @@ def skip_NDEvent [Machine CTX M] : _NDEvent M α β :=
 
 
 -- Remark: The functor instance is existential, not surprising given the relational context
-instance [Machine CTX M] : Functor (_NDEvent M γ) where
+instance [@Machine CTX M] : Functor (_NDEvent M γ) where
   map f ev :=
   {
     guard := ev.guard
@@ -106,7 +106,7 @@ instance [Machine CTX M] : Functor (_NDEvent M γ) where
                                                  ∧ y = f z ∧ m' = m''
   }
 
-instance [Machine CTX M] : LawfulFunctor (_NDEvent M γ) where
+instance [@Machine CTX M] : LawfulFunctor (_NDEvent M γ) where
   map_const := rfl
   id_map ev := by simp [Functor.map]
 
@@ -136,47 +136,47 @@ instance [Machine CTX M] : LawfulFunctor (_NDEvent M γ) where
 
 -- The first operates on the output, hence it cannot be use
 -- in a profunctor context
-instance [Machine CTX M] : ContravariantFunctor (_NDEvent M γ) where
+instance [@Machine CTX M] : ContravariantFunctor (_NDEvent M γ) where
   contramap f ev :=
   {
     guard := ev.guard
     effect := fun m x grd (y, m') => ev.effect m x grd ((f y), m')
   }
 
-instance [Machine CTX M] : LawfullContravariantFunctor (_NDEvent M β) where
+instance [@Machine CTX M] : LawfullContravariantFunctor (_NDEvent M β) where
   cmap_id _ := rfl
   cmap_comp _ _ := rfl
 
 -- The second operates on the input
-abbrev _CoNDEvent (M) [Machine CTX M] (α) (β) := _NDEvent M β α
+abbrev _CoNDEvent (M) [@Machine CTX M] (α) (β) := _NDEvent M β α
 
 @[simp]
-def CoNDEvent_from_NDEvent [Machine CTX M] (ev : _NDEvent M α β) : _CoNDEvent M β α :=
+def CoNDEvent_from_NDEvent [@Machine CTX M] (ev : _NDEvent M α β) : _CoNDEvent M β α :=
  ev
 
 @[simp]
-def NDEvent_from_CoNDEvent [Machine CTX M] (ev : _CoNDEvent M β α) : _NDEvent M α β :=
+def NDEvent_from_CoNDEvent [@Machine CTX M] (ev : _CoNDEvent M β α) : _NDEvent M α β :=
  ev
 
 
-instance [Machine CTX M] : ContravariantFunctor (_CoNDEvent M γ) where
+instance [@Machine CTX M] : ContravariantFunctor (_CoNDEvent M γ) where
   contramap f ev :=
   {
      guard := fun m x => ev.guard m (f x)
      effect := fun m x grd (y, m')  => ev.effect m (f x) grd (y, m')
   }
 
-instance [Machine CTX M] : LawfullContravariantFunctor (_CoNDEvent M γ) where
+instance [@Machine CTX M] : LawfullContravariantFunctor (_CoNDEvent M γ) where
   cmap_id _ := rfl
   cmap_comp _ _ := rfl
 
 -- There is a unique possible profunctor instance
-instance [Machine CTX M] : Profunctor (_NDEvent M) where
+instance [@Machine CTX M] : Profunctor (_NDEvent M) where
   dimap {α β} {γ δ} (f : β → α) (g : γ → δ) (ev : _NDEvent M α γ) : _NDEvent M β δ :=
   let ev' := NDEvent_from_CoNDEvent (ContravariantFunctor.contramap f (CoNDEvent_from_NDEvent ev))
   g <$> ev'
 
-instance [Machine CTX M] : LawfulProfunctor (_NDEvent M) where
+instance [@Machine CTX M] : LawfulProfunctor (_NDEvent M) where
   dimap_id := by simp [Profunctor.dimap, ContravariantFunctor.contramap]
                  exact fun {α β} => rfl
   dimap_comp f f' g g' := by
@@ -204,17 +204,17 @@ instance [Machine CTX M] : LawfulProfunctor (_NDEvent M) where
           exists u
           simp [Heff, Hy]
 
-instance [Machine CTX M] : StrongProfunctor (_NDEvent M) where
+instance [@Machine CTX M] : StrongProfunctor (_NDEvent M) where
   first' {α β γ} (ev : _NDEvent M α β): _NDEvent M (α × γ) (β × γ) :=
     {
       guard := fun m (x, _) => ev.guard m x
       effect := fun m (x,u) grd ((y, v), m') => v = u ∧ ev.effect m x grd (y, m')
     }
 
-instance [Machine CTX M] : LawfulStrongProfunctor (_NDEvent M) where
+instance [@Machine CTX M] : LawfulStrongProfunctor (_NDEvent M) where
 
 
-instance [Machine CTX M]: Category (_NDEvent M) where
+instance [@Machine CTX M]: Category (_NDEvent M) where
   id := {
     effect := fun m x _ (y, m') => y = x ∧ m' = m
   }
@@ -230,7 +230,7 @@ instance [Machine CTX M]: Category (_NDEvent M) where
                   ev₂.effect m' y (grd.2 grd.1 y m' eff₁) (z, m''))
     }
 
-theorem LawfulCategory_assoc_guard [Machine CTX M] (ev₁ : _NDEvent M γ δ) (ev₂ : _NDEvent M β γ) (ev₃ : _NDEvent M α β):
+theorem LawfulCategory_assoc_guard [@Machine CTX M] (ev₁ : _NDEvent M γ δ) (ev₂ : _NDEvent M β γ) (ev₃ : _NDEvent M α β):
   (ev₁ (<<<) ev₂ (<<<) ev₃).guard = ((ev₁ (<<<) ev₂) (<<<) ev₃).guard :=
 by
   simp
@@ -271,7 +271,7 @@ by
 
 set_option maxHeartbeats 300000
 
-instance [Machine CTX M]: LawfulCategory (_NDEvent M) where
+instance [@Machine CTX M]: LawfulCategory (_NDEvent M) where
   id_right ev := by
     apply _NDEvent.ext'
     simp
@@ -334,14 +334,14 @@ instance [Machine CTX M]: LawfulCategory (_NDEvent M) where
 
 
 @[simp]
-def arrow_NDEvent (M) [Machine CTX M] (f : α → β) : _NDEvent M α β :=
+def arrow_NDEvent (M) [@Machine CTX M] (f : α → β) : _NDEvent M α β :=
   {
     effect := fun m x _ (y, m') => y = f x ∧ m' = m
   }
 
 -- Split is simply parallel composition
 @[simp]
-def split_NDEvent [Machine CTX M] (ev₁ : _NDEvent M α β) (ev₂ : _NDEvent M γ δ) : _NDEvent M (α × γ) (β × δ) :=
+def split_NDEvent [@Machine CTX M] (ev₁ : _NDEvent M α β) (ev₂ : _NDEvent M γ δ) : _NDEvent M (α × γ) (β × δ) :=
   {
     guard := fun m (x, y) => ev₁.guard m x ∧ ev₂.guard m y
     effect := fun m (x, y) grd ((x', y'), m') => ev₁.effect m x grd.1 (x', m') ∧ ev₂.effect m y grd.2 (y', m')
@@ -349,7 +349,7 @@ def split_NDEvent [Machine CTX M] (ev₁ : _NDEvent M α β) (ev₂ : _NDEvent M
 
 -- Remark: without an explicit first the law `arrow_unit` is not provable
 @[simp]
-def first_NDEvent [Machine CTX M] (ev : _NDEvent M α β) : _NDEvent M (α × γ) (β × γ) :=
+def first_NDEvent [@Machine CTX M] (ev : _NDEvent M α β) : _NDEvent M (α × γ) (β × γ) :=
   {
     guard := fun m (x, _) => ev.guard m x
     effect := fun m (x, y) grd ((x', y'), m') => ev.effect m x grd (x', m') ∧ y'= y
@@ -358,19 +358,19 @@ def first_NDEvent [Machine CTX M] (ev : _NDEvent M α β) : _NDEvent M (α × γ
 -- An alternative possible definition for split based on first
 
 @[simp]
-def split_NDEvent_fromFirst [Machine CTX M] (ev₁ : _NDEvent M α β) (ev₂ : _NDEvent M γ δ) : _NDEvent M (α × γ) (β × δ) :=
+def split_NDEvent_fromFirst [@Machine CTX M] (ev₁ : _NDEvent M α β) (ev₂ : _NDEvent M γ δ) : _NDEvent M (α × γ) (β × δ) :=
   Arrow.split_from_first (arrow_NDEvent M (fun (x, y) => (y, x)))
                          first_NDEvent ev₁ ev₂
 
 /-
-instance [Machine CTX M]: Arrow (_NDEvent M) where
+instance [@Machine CTX M]: Arrow (_NDEvent M) where
   arrow := arrow_NDEvent M
   split := split_NDEvent
   first := first_NDEvent
 -/
 
 -- a more direct definition
-instance [Machine CTX M] [Semigroup M]: Arrow (_NDEvent M) where
+instance [@Machine CTX M] [Semigroup M]: Arrow (_NDEvent M) where
   arrow {α β} (f : α → β) : _NDEvent M α β := {
     guard := fun _ _ => True
     effect := fun m x _ (y, m') => y = f x ∧ m' = m
@@ -383,7 +383,7 @@ instance [Machine CTX M] [Semigroup M]: Arrow (_NDEvent M) where
   }
   first := first_NDEvent
 
-instance [Machine CTX M] [Semigroup M]: LawfulArrow (_NDEvent M) where
+instance [@Machine CTX M] [Semigroup M]: LawfulArrow (_NDEvent M) where
   arrow_id := by simp [Arrow.arrow]
   arrow_ext f := by
     simp [Arrow.arrow, Arrow.first]
@@ -457,7 +457,7 @@ instance [Machine CTX M] [Semigroup M]: LawfulArrow (_NDEvent M) where
 
 /-  Other misc. combinators -/
 
-def dlfNDEvent [Machine CTX M] (ev₁ : _NDEvent M α β) (ev₂ : _NDEvent M α β)
+def dlfNDEvent [@Machine CTX M] (ev₁ : _NDEvent M α β) (ev₂ : _NDEvent M α β)
   : _NDEvent M α β :=
   {
     guard := fun m x => ev₁.guard m x ∨ ev₂.guard m x

--- a/LeanMachines/NonDet/Convergent.lean
+++ b/LeanMachines/NonDet/Convergent.lean
@@ -19,7 +19,7 @@ the deterministic case and common properties (e.g. what is convergence?).
 -/
 
 /-- The internal representation of proof obligations for anticipated events. -/
-structure _AnticipatedNDEventPO (v) [Preorder v] [instM:Machine CTX M] (ev : _NDEvent M α β) (kind : EventKind)
+structure _AnticipatedNDEventPO (v) [Preorder v] [instM:@Machine CTX M] (ev : _NDEvent M α β) (kind : EventKind)
           extends _Variant v (instM:=instM), _NDEventPO ev kind  where
 
   nonIncreasing (m : M) (x : α):
@@ -32,13 +32,13 @@ structure _AnticipatedNDEventPO (v) [Preorder v] [instM:Machine CTX M] (ev : _ND
 It is an event for machine type `M` with input type `α` and output type `β`.
 The non-increasing argument is based on the variant type `v` assumed
 to be a preorder. -/
-structure AnticipatedNDEvent (v) [Preorder v] (M) [Machine CTX M] (α) (β)
+structure AnticipatedNDEvent (v) [Preorder v] (M) [@Machine CTX M] (α) (β)
           extends (_NDEvent M α β)  where
   po : _AnticipatedNDEventPO v to_NDEvent (EventKind.TransNonDet Convergence.Anticipated)
 
 /-- The "downgrading" of an anticipated event to an ordinary one. -/
 @[simp]
-def AnticipatedNDEvent.toOrdinaryNDEvent [Preorder v] [Machine CTX M]
+def AnticipatedNDEvent.toOrdinaryNDEvent [Preorder v] [@Machine CTX M]
   (ev : AnticipatedNDEvent v M α β) : OrdinaryNDEvent M α β :=
   {
     to_NDEvent := ev.to_NDEvent
@@ -49,7 +49,7 @@ def AnticipatedNDEvent.toOrdinaryNDEvent [Preorder v] [Machine CTX M]
   }
 
 @[simp]
-private def AnticipatedNDEvent_fromOrdinary {v} [Preorder v] {M} [Machine CTX M] (ev : OrdinaryNDEvent M α β)
+private def AnticipatedNDEvent_fromOrdinary {v} [Preorder v] {M} [@Machine CTX M] (ev : OrdinaryNDEvent M α β)
   (variant : M → v)
   (Hnincr: ∀ (m : M) (x : α),
     Machine.invariant m
@@ -73,7 +73,7 @@ with input type `α` and output type `β`. The non-increasing proof relies
 Note that the guard, effect and safety PO of the event must be also
 specified, as in the ordinary case (cf. `OrdinaryNDEventSpec`).
   -/
-structure AnticipatedNDEventSpec (v) [Preorder v] {CTX} (M) [instM:Machine CTX M] (α) (β)
+structure AnticipatedNDEventSpec (v) [Preorder v] {CTX} (M) [instM:@Machine CTX M] (α) (β)
   extends _Variant v (instM:=instM), NDEventSpec M α β where
   /-- Proof obligation: the variant is non-increasing. -/
   nonIncreasing (m : M) (x : α):
@@ -85,11 +85,11 @@ structure AnticipatedNDEventSpec (v) [Preorder v] {CTX} (M) [instM:Machine CTX M
 /-- Construction of an anticipated non-deterministic event from a
 `AnticipatedNDEventSpec` specification. -/
 @[simp]
-def newAnticipatedNDEvent [Preorder v] [Machine CTX M] (ev : AnticipatedNDEventSpec v M α β) : AnticipatedNDEvent v M α β :=
+def newAnticipatedNDEvent [Preorder v] [@Machine CTX M] (ev : AnticipatedNDEventSpec v M α β) : AnticipatedNDEvent v M α β :=
   AnticipatedNDEvent_fromOrdinary (newNDEvent ev.toNDEventSpec) ev.to_Variant.variant ev.nonIncreasing
 
 /-- Variant of `AnticipatedNDEventSpec` with implicit `Unit` output type -/
-structure AnticipatedNDEventSpec' (v) [Preorder v] {CTX} (M) [instM:Machine CTX M] (α)
+structure AnticipatedNDEventSpec' (v) [Preorder v] {CTX} (M) [instM:@Machine CTX M] (α)
   extends _Variant v (instM:=instM), NDEventSpec' M α where
 
   nonIncreasing (m : M) (x : α):
@@ -99,7 +99,7 @@ structure AnticipatedNDEventSpec' (v) [Preorder v] {CTX} (M) [instM:Machine CTX 
              → variant m' ≤ variant m
 
 @[simp]
-def AnticipatedNDEventSpec'.toAnticipatedNDEventSpec [Preorder v] [Machine CTX M]
+def AnticipatedNDEventSpec'.toAnticipatedNDEventSpec [Preorder v] [@Machine CTX M]
   (ev : AnticipatedNDEventSpec' v M α) : AnticipatedNDEventSpec v M α Unit :=
   {
     toNDEventSpec := ev.toNDEventSpec
@@ -111,11 +111,11 @@ def AnticipatedNDEventSpec'.toAnticipatedNDEventSpec [Preorder v] [Machine CTX M
 
 /-- Variant of `newAnticipatedNDEvent` with implicit `Unit` output type -/
 @[simp]
-def newAnticipatedNDEvent' [Preorder v] [Machine CTX M] (ev : AnticipatedNDEventSpec' v M α) : AnticipatedNDEvent v M α Unit :=
+def newAnticipatedNDEvent' [Preorder v] [@Machine CTX M] (ev : AnticipatedNDEventSpec' v M α) : AnticipatedNDEvent v M α Unit :=
   newAnticipatedNDEvent ev.toAnticipatedNDEventSpec
 
 /-- Variant of `AnticipatedNDEventSpec` with implicit `Unit` input and output types -/
-structure AnticipatedNDEventSpec'' (v) [Preorder v] {CTX} (M) [instM:Machine CTX M]
+structure AnticipatedNDEventSpec'' (v) [Preorder v] {CTX} (M) [instM:@Machine CTX M]
   extends _Variant v (instM:=instM), NDEventSpec'' M where
 
   nonIncreasing (m : M):
@@ -125,7 +125,7 @@ structure AnticipatedNDEventSpec'' (v) [Preorder v] {CTX} (M) [instM:Machine CTX
              → variant m' ≤ variant m
 
 @[simp]
-def AnticipatedNDEventSpec''.toAnticipatedNDEventSpec [Preorder v] [Machine CTX M]
+def AnticipatedNDEventSpec''.toAnticipatedNDEventSpec [Preorder v] [@Machine CTX M]
   (ev : AnticipatedNDEventSpec'' v M) : AnticipatedNDEventSpec v M Unit Unit :=
   {
     toNDEventSpec := ev.toNDEventSpec
@@ -137,7 +137,7 @@ def AnticipatedNDEventSpec''.toAnticipatedNDEventSpec [Preorder v] [Machine CTX 
 
 /-- Variant of `newAnticipatedNDEvent` with implicit `Unit` input and output types -/
 @[simp]
-def newAnticipatedNDEvent'' [Preorder v] [Machine CTX M] (ev : AnticipatedNDEventSpec'' v M) : AnticipatedNDEvent v M Unit Unit :=
+def newAnticipatedNDEvent'' [Preorder v] [@Machine CTX M] (ev : AnticipatedNDEventSpec'' v M) : AnticipatedNDEvent v M Unit Unit :=
   newAnticipatedNDEvent ev.toAnticipatedNDEventSpec
 
 /-!
@@ -145,7 +145,7 @@ def newAnticipatedNDEvent'' [Preorder v] [Machine CTX M] (ev : AnticipatedNDEven
 -/
 
 /-- The internal representation of proof obligations for convergent events. -/
-structure _ConvergentNDEventPO (v) [Preorder v] [WellFoundedLT v] [Machine CTX M] (ev : _NDEvent M α β) (kind : EventKind)
+structure _ConvergentNDEventPO (v) [Preorder v] [WellFoundedLT v] [@Machine CTX M] (ev : _NDEvent M α β) (kind : EventKind)
           extends _AnticipatedNDEventPO v ev kind  where
 
   convergence (m : M) (x : α):
@@ -158,13 +158,13 @@ structure _ConvergentNDEventPO (v) [Preorder v] [WellFoundedLT v] [Machine CTX M
 It is an event for machine type `M` with input type `α` and output type `β`.
 The convergence argument is based on the variant type `v` assumed
 to be a well-founded preorder. -/
-structure ConvergentNDEvent (v) [Preorder v]  [WellFoundedLT v] (M) [Machine CTX M] (α) (β)
+structure ConvergentNDEvent (v) [Preorder v]  [WellFoundedLT v] (M) [@Machine CTX M] (α) (β)
           extends (_NDEvent M α β)  where
   po : _ConvergentNDEventPO v to_NDEvent (EventKind.TransNonDet Convergence.Convergent)
 
 /-- The "downgrading" of a convergent event to an anticipated one. -/
 @[simp]
-def ConvergentNDEvent.toAnticipatedNDEvent [Preorder v] [WellFoundedLT v] [Machine CTX M]
+def ConvergentNDEvent.toAnticipatedNDEvent [Preorder v] [WellFoundedLT v] [@Machine CTX M]
   (ev : ConvergentNDEvent v M α β) : AnticipatedNDEvent v M α β :=
   {
     to_NDEvent := ev.to_NDEvent
@@ -177,7 +177,7 @@ def ConvergentNDEvent.toAnticipatedNDEvent [Preorder v] [WellFoundedLT v] [Machi
   }
 
 
-private def ConvergentNDEvent_fromOrdinary  {v} [Preorder v] [WellFoundedLT v] {M} [Machine CTX M] (ev : OrdinaryNDEvent M α β)
+private def ConvergentNDEvent_fromOrdinary  {v} [Preorder v] [WellFoundedLT v] {M} [@Machine CTX M] (ev : OrdinaryNDEvent M α β)
   (variant : M → v)
   (Hconv: ∀ (m : M) (x : α),
     Machine.invariant m
@@ -209,7 +209,7 @@ with input type `α` and output type `β`. The convergence proof relies
 Note that the guard, action and safety PO of the event must be also
 specified, as in the ordinary case (cf. `OrdinaryNDEventSpec`).
   -/
-structure ConvergentNDEventSpec (v) [Preorder v] [WellFoundedLT v] (M) [instM:Machine CTX M] (α) (β)
+structure ConvergentNDEventSpec (v) [Preorder v] [WellFoundedLT v] (M) [instM:@Machine CTX M] (α) (β)
   extends _Variant v (instM:=instM), NDEventSpec M α β where
   /-- Proof obligation: the variant is strictly decreasing. -/
   convergence (m : M) (x : α):
@@ -221,11 +221,11 @@ structure ConvergentNDEventSpec (v) [Preorder v] [WellFoundedLT v] (M) [instM:Ma
 /-- Construction of a convergent non-deterministic event from a
 `ConvergentNDEventSpec` specification. -/
 @[simp]
-def newConvergentNDEvent {v} [Preorder v] [WellFoundedLT v] {M} [Machine CTX M] (ev : ConvergentNDEventSpec v M α β) : ConvergentNDEvent v M α β :=
+def newConvergentNDEvent {v} [Preorder v] [WellFoundedLT v] {M} [@Machine CTX M] (ev : ConvergentNDEventSpec v M α β) : ConvergentNDEvent v M α β :=
   ConvergentNDEvent_fromOrdinary (newNDEvent ev.toNDEventSpec) ev.to_Variant.variant ev.convergence
 
 @[simp]
-private def ConvergentNDEvent_fromAnticipated {v} [Preorder v] [WellFoundedLT v] {M} [Machine CTX M] (ev : AnticipatedNDEvent v M α β)
+private def ConvergentNDEvent_fromAnticipated {v} [Preorder v] [WellFoundedLT v] {M} [@Machine CTX M] (ev : AnticipatedNDEvent v M α β)
     (hconv : (m : M) → (x : α)
     → Machine.invariant m
     → (grd : ev.guard m x)
@@ -244,7 +244,7 @@ private def ConvergentNDEvent_fromAnticipated {v} [Preorder v] [WellFoundedLT v]
   }
 
 /-- Variant of `ConvergentNDEventSpec` with implicit `Unit` output type -/
-structure ConvergentNDEventSpec' (v) [Preorder v] [WellFoundedLT v] (M) [instM:Machine CTX M] (α)
+structure ConvergentNDEventSpec' (v) [Preorder v] [WellFoundedLT v] (M) [instM:@Machine CTX M] (α)
   extends _Variant v (instM:=instM), NDEventSpec' M α where
 
   convergence (m : M) (x : α):
@@ -254,7 +254,7 @@ structure ConvergentNDEventSpec' (v) [Preorder v] [WellFoundedLT v] (M) [instM:M
              → variant m' < variant m
 
 @[simp]
-def ConvergentNDEventSpec'.toConvergentNDEventSpec [Preorder v] [WellFoundedLT v] {M} [Machine CTX M]
+def ConvergentNDEventSpec'.toConvergentNDEventSpec [Preorder v] [WellFoundedLT v] {M} [@Machine CTX M]
   (ev : ConvergentNDEventSpec' v M α) : ConvergentNDEventSpec v M α Unit :=
   {
     toNDEventSpec := ev.toNDEventSpec
@@ -266,11 +266,11 @@ def ConvergentNDEventSpec'.toConvergentNDEventSpec [Preorder v] [WellFoundedLT v
 
 /-- Variant of `newConvergentNDEvent` with implicit `Unit` output type -/
 @[simp]
-def newConvergentNDEvent' [Preorder v] [WellFoundedLT v] [Machine CTX M] (ev : ConvergentNDEventSpec' v M α) : ConvergentNDEvent v M α Unit :=
+def newConvergentNDEvent' [Preorder v] [WellFoundedLT v] [@Machine CTX M] (ev : ConvergentNDEventSpec' v M α) : ConvergentNDEvent v M α Unit :=
   newConvergentNDEvent ev.toConvergentNDEventSpec
 
 /-- Variant of `ConvergentNDEventSpec` with implicit `Unit` input and output types -/
-structure ConvergentNDEventSpec'' (v) [Preorder v] [WellFoundedLT v] (M) [instM:Machine CTX M]
+structure ConvergentNDEventSpec'' (v) [Preorder v] [WellFoundedLT v] (M) [instM:@Machine CTX M]
   extends _Variant v (instM:=instM), NDEventSpec'' M where
 
   convergence (m : M):
@@ -280,7 +280,7 @@ structure ConvergentNDEventSpec'' (v) [Preorder v] [WellFoundedLT v] (M) [instM:
              → variant m' < variant m
 
 @[simp]
-def ConvergentNDEventSpec''.toConvergentNDEventSpec [Preorder v] [WellFoundedLT v] [Machine CTX M]
+def ConvergentNDEventSpec''.toConvergentNDEventSpec [Preorder v] [WellFoundedLT v] [@Machine CTX M]
   (ev : ConvergentNDEventSpec'' v M) : ConvergentNDEventSpec v M Unit Unit :=
   {
     toNDEventSpec := ev.toNDEventSpec
@@ -292,7 +292,7 @@ def ConvergentNDEventSpec''.toConvergentNDEventSpec [Preorder v] [WellFoundedLT 
 
 /-- Variant of `newConvergentEvent` with implicit `Unit` input and output types -/
 @[simp]
-def newConvergentNDEvent'' [Preorder v] [WellFoundedLT v] [Machine CTX M] (ev : ConvergentNDEventSpec'' v M) : ConvergentNDEvent v M Unit Unit :=
+def newConvergentNDEvent'' [Preorder v] [WellFoundedLT v] [@Machine CTX M] (ev : ConvergentNDEventSpec'' v M) : ConvergentNDEvent v M Unit Unit :=
   newConvergentNDEvent ev.toConvergentNDEventSpec
 
 /-!
@@ -303,7 +303,7 @@ and convergent non-deterministic events (experimental, not documented).
 
 -/
 
-instance [Preorder v] [Machine CTX M] : Functor (AnticipatedNDEvent v M γ) where
+instance [Preorder v] [@Machine CTX M] : Functor (AnticipatedNDEvent v M γ) where
   map f ev := {
     to_NDEvent := f <$> ev.to_NDEvent
     po := {
@@ -331,7 +331,7 @@ instance [Preorder v] [Machine CTX M] : Functor (AnticipatedNDEvent v M γ) wher
   }
 
 /- TODO : issue with dependent equality, should be workable ...
-instance [Preorder v] [Machine CTX M] : LawfulFunctor (AnticipatedNDEvent v M γ) where
+instance [Preorder v] [@Machine CTX M] : LawfulFunctor (AnticipatedNDEvent v M γ) where
   map_const := by simp [Functor.map, Functor.mapConst]
   id_map ev := by simp [Functor.map]
                   cases ev
@@ -353,7 +353,7 @@ instance [Preorder v] [Machine CTX M] : LawfulFunctor (AnticipatedNDEvent v M γ
 ... -/
 
 
-instance [Preorder v] [WellFoundedLT v] [Machine CTX M] : Functor (ConvergentNDEvent v M γ) where
+instance [Preorder v] [WellFoundedLT v] [@Machine CTX M] : Functor (ConvergentNDEvent v M γ) where
   map f ev := {
     to_NDEvent := f <$> ev.to_NDEvent
     po := {
@@ -387,7 +387,7 @@ instance [Preorder v] [WellFoundedLT v] [Machine CTX M] : Functor (ConvergentNDE
   }
 
 /- TODO : issue with dependent equality, should be workable ...
-instance [Preorder v] [WellFoundedLT v] [Machine CTX M] : LawfulFunctor (ConvergentNDEvent v M γ) where
+instance [Preorder v] [WellFoundedLT v] [@Machine CTX M] : LawfulFunctor (ConvergentNDEvent v M γ) where
   map_const := by simp [Functor.map, Functor.mapConst]
   id_map ev := by cases ev
                   case mk _ev po =>
@@ -402,17 +402,17 @@ instance [Preorder v] [WellFoundedLT v] [Machine CTX M] : LawfulFunctor (Converg
                         sorry
 -/
 
-abbrev CoAnticipatedNDEvent (v) [Preorder v] (M) [Machine CTX M] (α) (β) := AnticipatedNDEvent v M β α
+abbrev CoAnticipatedNDEvent (v) [Preorder v] (M) [@Machine CTX M] (α) (β) := AnticipatedNDEvent v M β α
 
 @[simp]
-def CoAnticipatedNDEvent_from_AnticipatedNDEvent [Preorder v] [Machine CTX M] (ev : AnticipatedNDEvent v M α β) : CoAnticipatedNDEvent v M β α :=
+def CoAnticipatedNDEvent_from_AnticipatedNDEvent [Preorder v] [@Machine CTX M] (ev : AnticipatedNDEvent v M α β) : CoAnticipatedNDEvent v M β α :=
  ev
 
 @[simp]
-def AnticipatedNDEvent_from_CoAnticipatedNDEvent [Preorder v] [Machine CTX M] (ev : CoAnticipatedNDEvent v M β α) : AnticipatedNDEvent v M α β :=
+def AnticipatedNDEvent_from_CoAnticipatedNDEvent [Preorder v] [@Machine CTX M] (ev : CoAnticipatedNDEvent v M β α) : AnticipatedNDEvent v M α β :=
  ev
 
-instance [Preorder v] [Machine CTX M] : ContravariantFunctor (CoAnticipatedNDEvent v M γ) where
+instance [Preorder v] [@Machine CTX M] : ContravariantFunctor (CoAnticipatedNDEvent v M γ) where
   contramap {α β} (f : β → α) event :=
   let ev : _CoNDEvent M γ β := ContravariantFunctor.contramap f event.to_NDEvent
   {
@@ -449,21 +449,21 @@ instance [Preorder v] [Machine CTX M] : ContravariantFunctor (CoAnticipatedNDEve
      }
   }
 
-instance [Preorder v] [WellFoundedLT v] [Machine CTX M] : LawfullContravariantFunctor (CoAnticipatedNDEvent v M γ) where
+instance [Preorder v] [WellFoundedLT v] [@Machine CTX M] : LawfullContravariantFunctor (CoAnticipatedNDEvent v M γ) where
   cmap_id _ := rfl
   cmap_comp _ _ := rfl
 
-abbrev CoConvergentNDEvent (v) [Preorder v] [WellFoundedLT v]  (M) [Machine CTX M] (α) (β) := ConvergentNDEvent v M β α
+abbrev CoConvergentNDEvent (v) [Preorder v] [WellFoundedLT v]  (M) [@Machine CTX M] (α) (β) := ConvergentNDEvent v M β α
 
 @[simp]
-def CoConvergentNDEvent_from_ConvergentNDEvent [Preorder v] [WellFoundedLT v] [Machine CTX M] (ev : ConvergentNDEvent v M α β) : CoConvergentNDEvent v M β α :=
+def CoConvergentNDEvent_from_ConvergentNDEvent [Preorder v] [WellFoundedLT v] [@Machine CTX M] (ev : ConvergentNDEvent v M α β) : CoConvergentNDEvent v M β α :=
  ev
 
 @[simp]
-def ConvergentNDEvent_from_CoConvergentNDEvent [Preorder v] [WellFoundedLT v] [Machine CTX M] (ev : CoConvergentNDEvent v M β α) : ConvergentNDEvent v M α β :=
+def ConvergentNDEvent_from_CoConvergentNDEvent [Preorder v] [WellFoundedLT v] [@Machine CTX M] (ev : CoConvergentNDEvent v M β α) : ConvergentNDEvent v M α β :=
  ev
 
-instance [Preorder v] [WellFoundedLT v]  [Machine CTX M] : ContravariantFunctor (CoConvergentNDEvent v M γ) where
+instance [Preorder v] [WellFoundedLT v]  [@Machine CTX M] : ContravariantFunctor (CoConvergentNDEvent v M γ) where
   contramap {α β} (f : β → α) event :=
   let ev : _CoNDEvent M γ β := ContravariantFunctor.contramap f event.to_NDEvent
   {
@@ -512,20 +512,20 @@ instance [Preorder v] [WellFoundedLT v]  [Machine CTX M] : ContravariantFunctor 
      }
   }
 
-instance [Preorder v] [WellFoundedLT v] [Machine CTX M] : LawfullContravariantFunctor (CoConvergentNDEvent v M γ) where
+instance [Preorder v] [WellFoundedLT v] [@Machine CTX M] : LawfullContravariantFunctor (CoConvergentNDEvent v M γ) where
   cmap_id _ := rfl
   cmap_comp _ _ := rfl
 
 /- Profunctor -/
 
-instance [Preorder v] [Machine CTX M] : Profunctor (AnticipatedNDEvent v M) where
+instance [Preorder v] [@Machine CTX M] : Profunctor (AnticipatedNDEvent v M) where
   dimap {α β} {γ δ} (f : β → α) (g : γ → δ) (ev : AnticipatedNDEvent v M α γ) : AnticipatedNDEvent v M β δ :=
   let ev' := AnticipatedNDEvent_from_CoAnticipatedNDEvent (ContravariantFunctor.contramap f (CoAnticipatedNDEvent_from_AnticipatedNDEvent ev))
   g <$> ev'
 
 
 /- TODO : issue with dependent equality, should be workable ...
-instance  [Preorder v] [Machine CTX M] : LawfulProfunctor (AnticipatedNDEvent v M) where
+instance  [Preorder v] [@Machine CTX M] : LawfulProfunctor (AnticipatedNDEvent v M) where
   dimap_id := by simp [Profunctor.dimap, ContravariantFunctor.contramap]
                  exact fun {α β} => rfl
   dimap_comp f f' g g' := by funext event
@@ -544,7 +544,7 @@ instance  [Preorder v] [Machine CTX M] : LawfulProfunctor (AnticipatedNDEvent v 
                                  sorry
 -/
 
-instance [Preorder v] [Machine CTX M] : StrongProfunctor (AnticipatedNDEvent v M) where
+instance [Preorder v] [@Machine CTX M] : StrongProfunctor (AnticipatedNDEvent v M) where
   first' {α β γ} (event : AnticipatedNDEvent v M α β): AnticipatedNDEvent v M (α × γ) (β × γ) :=
     let ev : _NDEvent M (α × γ) (β × γ) := StrongProfunctor.first' event.to_NDEvent
     {
@@ -580,16 +580,16 @@ instance [Preorder v] [Machine CTX M] : StrongProfunctor (AnticipatedNDEvent v M
     }
 
 -- TODO: lawful strong profunctor
--- instance [Preorder v] [Machine CTX M] : LawfulStrongProfunctor (AnticipatedNDEvent v M) where
+-- instance [Preorder v] [@Machine CTX M] : LawfulStrongProfunctor (AnticipatedNDEvent v M) where
 
-instance [Preorder v] [WellFoundedLT v] [Machine CTX M] : Profunctor (ConvergentNDEvent v M) where
+instance [Preorder v] [WellFoundedLT v] [@Machine CTX M] : Profunctor (ConvergentNDEvent v M) where
   dimap {α β} {γ δ} (f : β → α) (g : γ → δ) (ev : ConvergentNDEvent v M α γ) : ConvergentNDEvent v M β δ :=
   let ev' := ConvergentNDEvent_from_CoConvergentNDEvent (ContravariantFunctor.contramap f (CoConvergentNDEvent_from_ConvergentNDEvent ev))
   g <$> ev'
 
 
 /- TODO : issue with dependent equality, should be workable ...
-instance  [Preorder v] [WellFoundedLT v] [Machine CTX M] : LawfulProfunctor (ConvergentNDEvent v M) where
+instance  [Preorder v] [WellFoundedLT v] [@Machine CTX M] : LawfulProfunctor (ConvergentNDEvent v M) where
   dimap_id := by simp [Profunctor.dimap, ContravariantFunctor.contramap]
                  exact fun {α β} => rfl
   dimap_comp f f' g g' := by funext event
@@ -608,7 +608,7 @@ instance  [Preorder v] [WellFoundedLT v] [Machine CTX M] : LawfulProfunctor (Con
                                  sorry
 -/
 
-instance [Preorder v] [WellFoundedLT v] [Machine CTX M] : StrongProfunctor (ConvergentNDEvent v M) where
+instance [Preorder v] [WellFoundedLT v] [@Machine CTX M] : StrongProfunctor (ConvergentNDEvent v M) where
   first' {α β γ} (event : ConvergentNDEvent v M α β): ConvergentNDEvent v M (α × γ) (β × γ) :=
     let ev : _NDEvent M (α × γ) (β × γ) := StrongProfunctor.first' event.to_NDEvent
     {
@@ -652,4 +652,4 @@ instance [Preorder v] [WellFoundedLT v] [Machine CTX M] : StrongProfunctor (Conv
     }
 
 -- TODO: lawful strong profunctor
--- instance [Preorder v] [WellFoundedLT v] [Machine CTX M] : LawfulStrongProfunctor (ConvergentNDEvent v M) where
+-- instance [Preorder v] [WellFoundedLT v] [@Machine CTX M] : LawfulStrongProfunctor (ConvergentNDEvent v M) where

--- a/LeanMachines/NonDet/Ordinary.lean
+++ b/LeanMachines/NonDet/Ordinary.lean
@@ -23,7 +23,7 @@ relational notion of effect
 
 /-- The internal representation of proof obligations for ordinary
 non-deterministic events. -/
-structure _NDEventPO [Machine CTX M] (ev : _NDEvent M α β) (kind : EventKind) where
+structure _NDEventPO [@Machine CTX M] (ev : _NDEvent M α β) (kind : EventKind) where
   safety (m : M) (x : α):
     Machine.invariant m
     → (grd : ev.guard m x)
@@ -37,10 +37,10 @@ structure _NDEventPO [Machine CTX M] (ev : _NDEvent M α β) (kind : EventKind) 
 
 /-- The type of non-deterministic events without convergence properties.
 It is an event for machine type `M` with input type `α` and output type `β` -/
-structure OrdinaryNDEvent (M) [Machine CTX M] (α) (β) extends _NDEvent M α β where
+structure OrdinaryNDEvent (M) [@Machine CTX M] (α) (β) extends _NDEvent M α β where
   po : _NDEventPO to_NDEvent  (EventKind.TransNonDet Convergence.Ordinary)
 
-theorem OrdinaryNDEvent.ext [Machine CTX M] (ev₁ : OrdinaryNDEvent M α β) (ev₂ : OrdinaryNDEvent M α β):
+theorem OrdinaryNDEvent.ext [@Machine CTX M] (ev₁ : OrdinaryNDEvent M α β) (ev₂ : OrdinaryNDEvent M α β):
   ev₁.to_NDEvent = ev₂.to_NDEvent
   → ev₁ = ev₂ :=
 by
@@ -48,7 +48,7 @@ by
 
 
 @[simp]
-def OrdinaryEvent.toOrdinaryNDEvent [Machine CTX M] (ev : OrdinaryEvent M α β) : OrdinaryNDEvent M α β :=
+def OrdinaryEvent.toOrdinaryNDEvent [@Machine CTX M] (ev : OrdinaryEvent M α β) : OrdinaryNDEvent M α β :=
   let event := ev.to_Event.to_NDEvent
 {
   guard := event.guard
@@ -64,7 +64,7 @@ def OrdinaryEvent.toOrdinaryNDEvent [Machine CTX M] (ev : OrdinaryEvent M α β)
 
 /-- The specification of a non-deterministic, ordinary event for machine `M`
 with input type `α` and output type `β`. . -/
-structure NDEventSpec (M) [Machine CTX M] (α) (β) where
+structure NDEventSpec (M) [@Machine CTX M] (α) (β) where
   /-- The guard property of the event, in machine state `m` with input `x`. -/
   guard (m : M) (x : α) : Prop := True
 
@@ -96,7 +96,7 @@ structure NDEventSpec (M) [Machine CTX M] (α) (β) where
     → ∃ y, ∃ m', effect m x grd (y, m')
 
 @[simp]
-def NDEventSpec.to_NDEvent [Machine CTX M] (ev : NDEventSpec M α β) : _NDEvent M α β :=
+def NDEventSpec.to_NDEvent [@Machine CTX M] (ev : NDEventSpec M α β) : _NDEvent M α β :=
   { guard := ev.guard
     effect := ev.effect
   }
@@ -104,7 +104,7 @@ def NDEventSpec.to_NDEvent [Machine CTX M] (ev : NDEventSpec M α β) : _NDEvent
 /-- Construction of an ordinary non-deterministic event from a
 `NDEventSpec` specification. -/
 @[simp]
-def newNDEvent {M} [Machine CTX M] (ev : NDEventSpec M α β) : OrdinaryNDEvent M α β :=
+def newNDEvent {M} [@Machine CTX M] (ev : NDEventSpec M α β) : OrdinaryNDEvent M α β :=
   {
     to_NDEvent := ev.to_NDEvent
     po := { safety := fun m x => by simp
@@ -117,7 +117,7 @@ def newNDEvent {M} [Machine CTX M] (ev : NDEventSpec M α β) : OrdinaryNDEvent 
   }
 
 /-- Variant of `NDEventSpec` with implicit `Unit` output type -/
-structure NDEventSpec' (M) [Machine CTX M] (α) where
+structure NDEventSpec' (M) [@Machine CTX M] (α) where
   guard (m : M) (x : α) : Prop := True
   effect (m : M) (x : α) (grd : guard m x) (m' : M) : Prop
 
@@ -133,7 +133,7 @@ structure NDEventSpec' (M) [Machine CTX M] (α) where
     → ∃ m', effect m x grd m'
 
 @[simp]
-def NDEventSpec'.toNDEventSpec [Machine CTX M] (ev : NDEventSpec' M α) : NDEventSpec M α Unit :=
+def NDEventSpec'.toNDEventSpec [@Machine CTX M] (ev : NDEventSpec' M α) : NDEventSpec M α Unit :=
   { guard := ev.guard
     effect := fun m x grd ((), m') => ev.effect m x grd m'
     safety := fun m x => by simp ; apply ev.safety
@@ -142,11 +142,11 @@ def NDEventSpec'.toNDEventSpec [Machine CTX M] (ev : NDEventSpec' M α) : NDEven
 
 /-- Variant of `newNDEvent` with implicit `Unit` output type -/
 @[simp]
-def newNDEvent' {M} [Machine CTX M] (ev : NDEventSpec' M α) : OrdinaryNDEvent M α Unit :=
+def newNDEvent' {M} [@Machine CTX M] (ev : NDEventSpec' M α) : OrdinaryNDEvent M α Unit :=
   newNDEvent ev.toNDEventSpec
 
 /-- Variant of `NDEventSpec` with implicit `Unit` input and output types -/
-structure NDEventSpec'' (M) [Machine CTX M] where
+structure NDEventSpec'' (M) [@Machine CTX M] where
   guard (m : M) : Prop := True
   effect (m : M) (grd : guard m) (m' : M) : Prop
 
@@ -162,7 +162,7 @@ structure NDEventSpec'' (M) [Machine CTX M] where
     → ∃ m', effect m grd m'
 
 @[simp]
-def NDEventSpec''.toNDEventSpec [Machine CTX M] (ev : NDEventSpec'' M) : NDEventSpec M Unit Unit :=
+def NDEventSpec''.toNDEventSpec [@Machine CTX M] (ev : NDEventSpec'' M) : NDEventSpec M Unit Unit :=
   { guard := fun m _ => ev.guard m
     effect := fun m () grd ((), m') => ev.effect m grd m'
     safety := fun m x => by
@@ -177,7 +177,7 @@ def NDEventSpec''.toNDEventSpec [Machine CTX M] (ev : NDEventSpec'' M) : NDEvent
 
 /-- Variant of `newNDEvent` with implicit `Unit` input and output types -/
 @[simp]
-def newNDEvent'' {M} [Machine CTX M] (ev : NDEventSpec'' M) : OrdinaryNDEvent M Unit Unit :=
+def newNDEvent'' {M} [@Machine CTX M] (ev : NDEventSpec'' M) : OrdinaryNDEvent M Unit Unit :=
   newNDEvent ev.toNDEventSpec
 
 /-!
@@ -185,7 +185,7 @@ def newNDEvent'' {M} [Machine CTX M] (ev : NDEventSpec'' M) : OrdinaryNDEvent M 
 -/
 
 /-- The internal representation of proof obligations for initialization events. -/
-structure _InitNDEventPO [Machine CTX M] (ev : _InitNDEvent M α β) (kind : EventKind) where
+structure _InitNDEventPO [@Machine CTX M] (ev : _InitNDEvent M α β) (kind : EventKind) where
   safety (x : α):
     (grd : ev.guard x)
     → ∀ y, ∀ m', ev.init x grd (y, m')
@@ -197,14 +197,14 @@ structure _InitNDEventPO [Machine CTX M] (ev : _InitNDEvent M α β) (kind : Eve
 
 /-- Type type of non-deterministic initialization events.
 It is an event for machine type `M` with input type `α` and output type `β` -/
-structure InitNDEvent (M) [Machine CTX M] (α) (β) extends _InitNDEvent M α β where
+structure InitNDEvent (M) [@Machine CTX M] (α) (β) extends _InitNDEvent M α β where
   po : _InitNDEventPO to_InitNDEvent  EventKind.InitNonDet
 
 /-- The specification of a non-deterministic intialization event for machine `M`
 with input type `α` and output type `β`.
 The effect of the event is called an `init`.
 -/
-structure InitNDEventSpec (M) [Machine CTX M] (α) (β) where
+structure InitNDEventSpec (M) [@Machine CTX M] (α) (β) where
   /-- The guard property of the event, an initialization with input `x`. -/
   guard (x : α) : Prop := True
   /-- The (non-deterministic) effect of the event, with
@@ -222,7 +222,7 @@ structure InitNDEventSpec (M) [Machine CTX M] (α) (β) where
     → ∃ y, ∃ m, init x grd (y, m)
 
 @[simp]
-def InitNDEventSpec.to_InitNDEvent [Machine CTX M]
+def InitNDEventSpec.to_InitNDEvent [@Machine CTX M]
   (ev : InitNDEventSpec M α β) : _InitNDEvent M α β :=
   {
     guard := ev.guard
@@ -232,7 +232,7 @@ def InitNDEventSpec.to_InitNDEvent [Machine CTX M]
 /-- Construction of a on-deterministic initialization event from a
 `InitNDEventSpec` specification. -/
 @[simp]
-def newInitNDEvent {M} [Machine CTX M] (ev : InitNDEventSpec M α β) : InitNDEvent M α β :=
+def newInitNDEvent {M} [@Machine CTX M] (ev : InitNDEventSpec M α β) : InitNDEvent M α β :=
   {
     to_InitNDEvent := ev.to_InitNDEvent
     po := {
@@ -244,7 +244,7 @@ def newInitNDEvent {M} [Machine CTX M] (ev : InitNDEventSpec M α β) : InitNDEv
   }
 
 /-- Variant of `InitNDEventSpec` with implicit `Unit` output type -/
-structure InitNDEventSpec' (M) [Machine CTX M] (α) where
+structure InitNDEventSpec' (M) [@Machine CTX M] (α) where
   guard (x : α) : Prop := True
   init (x : α) (grd : guard x) (m : M) : Prop
 
@@ -258,7 +258,7 @@ structure InitNDEventSpec' (M) [Machine CTX M] (α) where
     → ∃ m, init x grd m
 
 @[simp]
-def InitNDEventSpec'.toInitNDEventSpec [Machine CTX M] (ev : InitNDEventSpec' M α) : InitNDEventSpec M α Unit :=
+def InitNDEventSpec'.toInitNDEventSpec [@Machine CTX M] (ev : InitNDEventSpec' M α) : InitNDEventSpec M α Unit :=
   {
     guard := ev.guard
     init := fun x grd ((), m) => ev.init x grd m
@@ -274,12 +274,12 @@ def InitNDEventSpec'.toInitNDEventSpec [Machine CTX M] (ev : InitNDEventSpec' M 
 
 /-- Variant of `newInitNDEvent` with implicit `Unit` output type -/
 @[simp]
-def newInitNDEvent' [Machine CTX M] (ev : InitNDEventSpec' M α) : InitNDEvent M α Unit :=
+def newInitNDEvent' [@Machine CTX M] (ev : InitNDEventSpec' M α) : InitNDEvent M α Unit :=
   newInitNDEvent ev.toInitNDEventSpec
 
 
 /-- Variant of `InitNDEventSpec` with implicit `Unit` input and output types -/
-structure InitNDEventSpec'' (M) [Machine CTX M] where
+structure InitNDEventSpec'' (M) [@Machine CTX M] where
   guard : Prop := True
   init (grd : guard) (m : M) : Prop
 
@@ -293,7 +293,7 @@ structure InitNDEventSpec'' (M) [Machine CTX M] where
     → ∃ m, init grd m
 
 @[simp]
-def InitNDEventSpec''.toInitNDEventSpec [Machine CTX M] (ev : InitNDEventSpec'' M) : InitNDEventSpec M Unit Unit :=
+def InitNDEventSpec''.toInitNDEventSpec [@Machine CTX M] (ev : InitNDEventSpec'' M) : InitNDEventSpec M Unit Unit :=
   {
     guard := fun () => ev.guard
     init := fun () grd ((), m) => ev.init grd m
@@ -309,7 +309,7 @@ def InitNDEventSpec''.toInitNDEventSpec [Machine CTX M] (ev : InitNDEventSpec'' 
 
 /-- Variant of `newInitNDEvent` with implicit `Unit` input and output types -/
 @[simp]
-def newInitNDEvent'' [Machine CTX M] (ev : InitNDEventSpec'' M) : InitNDEvent M Unit Unit :=
+def newInitNDEvent'' [@Machine CTX M] (ev : InitNDEventSpec'' M) : InitNDEvent M Unit Unit :=
   newInitNDEvent ev.toInitNDEventSpec
 
 /-!
@@ -323,7 +323,7 @@ This part is rather experimental and is thus not fully documented yet.
 
 -/
 
-instance [Machine CTX M] : Functor (OrdinaryNDEvent M γ) where
+instance [@Machine CTX M] : Functor (OrdinaryNDEvent M γ) where
   map {α β} (f : α → β) event :=
   let ev' : _NDEvent M γ β := f <$> event.to_NDEvent
   {
@@ -346,7 +346,7 @@ instance [Machine CTX M] : Functor (OrdinaryNDEvent M γ) where
   }
 
 -- XXX: proofs are a little bit painful due to the existentials ...
-instance [Machine CTX M] : LawfulFunctor (OrdinaryNDEvent M γ) where
+instance [@Machine CTX M] : LawfulFunctor (OrdinaryNDEvent M γ) where
   map_const := rfl
   id_map ev := by simp [Functor.map]
 
@@ -362,7 +362,7 @@ instance [Machine CTX M] : LawfulFunctor (OrdinaryNDEvent M γ) where
 /- XXX:
 --  The output contravariant functor not provable, because we would
 -- need a iso morphisme between α and β.
-instance [Machine CTX M] : ContravariantFunctor (OrdinaryNDEvent M γ) where
+instance [@Machine CTX M] : ContravariantFunctor (OrdinaryNDEvent M γ) where
   contramap {α β} (f : β → α) event :=
   let ev' : _NDEvent M γ β := ContravariantFunctor.contramap f event.to_NDEvent
   {
@@ -385,18 +385,18 @@ instance [Machine CTX M] : ContravariantFunctor (OrdinaryNDEvent M γ) where
 
 
 -- The input contravariant functor
-abbrev CoOrdinaryNDEvent (M) [Machine CTX M] (α) (β) := OrdinaryNDEvent M β α
+abbrev CoOrdinaryNDEvent (M) [@Machine CTX M] (α) (β) := OrdinaryNDEvent M β α
 
 
 @[simp]
-def CoOrdinaryNDEvent_from_OrdinaryNDEvent [Machine CTX M] (ev : OrdinaryNDEvent M α β) : CoOrdinaryNDEvent M β α :=
+def CoOrdinaryNDEvent_from_OrdinaryNDEvent [@Machine CTX M] (ev : OrdinaryNDEvent M α β) : CoOrdinaryNDEvent M β α :=
  ev
 
 @[simp]
-def OrdinaryNDEvent_from_CoOrdinaryNDEvent [Machine CTX M] (ev : CoOrdinaryNDEvent M β α) : OrdinaryNDEvent M α β :=
+def OrdinaryNDEvent_from_CoOrdinaryNDEvent [@Machine CTX M] (ev : CoOrdinaryNDEvent M β α) : OrdinaryNDEvent M α β :=
  ev
 
-instance [Machine CTX M] : ContravariantFunctor (CoOrdinaryNDEvent M γ) where
+instance [@Machine CTX M] : ContravariantFunctor (CoOrdinaryNDEvent M γ) where
   contramap {α β} (f : β → α) event :=
   let ev : _CoNDEvent M γ β := ContravariantFunctor.contramap f event.to_NDEvent
   {
@@ -422,17 +422,17 @@ instance [Machine CTX M] : ContravariantFunctor (CoOrdinaryNDEvent M γ) where
      }
   }
 
-instance [Machine CTX M] : LawfullContravariantFunctor (CoOrdinaryNDEvent M γ) where
+instance [@Machine CTX M] : LawfullContravariantFunctor (CoOrdinaryNDEvent M γ) where
   cmap_id _ := rfl
   cmap_comp _ _ := rfl
 
-instance [Machine CTX M] : Profunctor (OrdinaryNDEvent M) where
+instance [@Machine CTX M] : Profunctor (OrdinaryNDEvent M) where
   dimap {α β} {γ δ} (f : β → α) (g : γ → δ) (ev : OrdinaryNDEvent M α γ) : OrdinaryNDEvent M β δ :=
   let ev' := OrdinaryNDEvent_from_CoOrdinaryNDEvent (ContravariantFunctor.contramap f (CoOrdinaryNDEvent_from_OrdinaryNDEvent ev))
   g <$> ev'
 
 
-instance [Machine CTX M] : LawfulProfunctor (OrdinaryNDEvent M) where
+instance [@Machine CTX M] : LawfulProfunctor (OrdinaryNDEvent M) where
   dimap_id := by simp [Profunctor.dimap, ContravariantFunctor.contramap]
                  exact fun {α β} => rfl
   dimap_comp f f' g g' := by
@@ -448,7 +448,7 @@ instance [Machine CTX M] : LawfulProfunctor (OrdinaryNDEvent M) where
         simp [Profunctor.dimap, ContravariantFunctor.contramap, Functor.map] at *
         simp [*]
 
-instance [Machine CTX M] : StrongProfunctor (OrdinaryNDEvent M) where
+instance [@Machine CTX M] : StrongProfunctor (OrdinaryNDEvent M) where
   first' {α β γ} (event : OrdinaryNDEvent M α β): OrdinaryNDEvent M (α × γ) (β × γ) :=
     let ev : _NDEvent M (α × γ) (β × γ) := StrongProfunctor.first' event.to_NDEvent
     {
@@ -471,9 +471,9 @@ instance [Machine CTX M] : StrongProfunctor (OrdinaryNDEvent M) where
       }
     }
 
-instance [Machine CTX M] : LawfulStrongProfunctor (OrdinaryNDEvent M) where
+instance [@Machine CTX M] : LawfulStrongProfunctor (OrdinaryNDEvent M) where
 
-instance [Machine CTX M]: Category (OrdinaryNDEvent M) where
+instance [@Machine CTX M]: Category (OrdinaryNDEvent M) where
   id {α }:=
   let ev : _NDEvent M α α := Category.id
   {
@@ -516,7 +516,7 @@ instance [Machine CTX M]: Category (OrdinaryNDEvent M) where
       }
     }
 
-instance [Machine CTX M]: LawfulCategory (OrdinaryNDEvent M) where
+instance [@Machine CTX M]: LawfulCategory (OrdinaryNDEvent M) where
   id_right ev := by
     simp
     have Hir := LawfulCategory.id_right ev.to_NDEvent
@@ -542,20 +542,20 @@ instance [Machine CTX M]: LawfulCategory (OrdinaryNDEvent M) where
 
 -- XXX: This axiom is required to obtain feasibility
 /-
-axiom OrdinaryNDEvent_split_feasibility_ax {CTX} {M} [Machine CTX M] [Semigroup M] {α β α' β'} (ev₁ : _NDEvent M α β)  (ev₂ : _NDEvent M α' β')
+axiom OrdinaryNDEvent_split_feasibility_ax {CTX} {M} [@Machine CTX M] [Semigroup M] {α β α' β'} (ev₁ : _NDEvent M α β)  (ev₂ : _NDEvent M α' β')
   (m : M) (x : α) (x' : α'):
   (∃ y, ∃ grd₁, ∃ m', ev₁.effect m x grd₁ (y, m'))
   → (∃ y', ∃ grd₂, ∃ m', ev₂.effect m x' grd₂ (y', m'))
   → (∃ y, ∃ y', ∃ m', (Arrow.split ev₁ ev₂).effect m (x, x') (by sorry) ((y, y'), m'))
 -/
 
-class ParallelMachine (M) [Machine CTX M] extends Semigroup M where
+class ParallelMachine (M) [@Machine CTX M] extends Semigroup M where
   par_safe (m₁ m₂ : M):
     Machine.invariant m₁
     → Machine.invariant m₂
     → Machine.invariant (m₁ * m₂)
 
-instance [Machine CTX M] [ParallelMachine M]: Arrow (OrdinaryNDEvent M) where
+instance [@Machine CTX M] [ParallelMachine M]: Arrow (OrdinaryNDEvent M) where
 
   arrow {α β} (f : α → β) :=
     let event : _NDEvent M α β := Arrow.arrow f
@@ -625,7 +625,7 @@ instance [Machine CTX M] [ParallelMachine M]: Arrow (OrdinaryNDEvent M) where
 
 
 
-instance [Machine CTX M] [ParallelMachine M]: LawfulArrow (OrdinaryNDEvent M) where
+instance [@Machine CTX M] [ParallelMachine M]: LawfulArrow (OrdinaryNDEvent M) where
   arrow_id := by simp [Arrow.arrow]
 
   arrow_ext {α β γ } f :=

--- a/LeanMachines/Refinement/Bidirectional/Basic.lean
+++ b/LeanMachines/Refinement/Bidirectional/Basic.lean
@@ -4,7 +4,7 @@ import LeanMachines.Refinement.Strong.Basic
 
 class BiRefinement {ACTX : outParam (Type u₁)} (AM)
                  {CTX : outParam (Type u₂)} (M)
-                 [Machine ACTX AM] [Machine CTX M] extends SRefinement AM M where
+                 [@Machine ACTX AM] [@Machine CTX M] extends SRefinement AM M where
 
   unlift_lift  (m m' : M):
     Machine.invariant m

--- a/LeanMachines/Refinement/Functional/Abstract.lean
+++ b/LeanMachines/Refinement/Functional/Abstract.lean
@@ -11,14 +11,14 @@ import LeanMachines.Refinement.Relational.Abstract
 open Refinement
 open FRefinement
 
-structure _AbstractFREventSpec (AM) [Machine ACTX AM]
-                              (M) [Machine CTX M]
+structure _AbstractFREventSpec (AM) [@Machine ACTX AM]
+                              (M) [@Machine CTX M]
                               [FRefinement AM M] (α) where
 
   unlift (am am' : AM) (m : M) (x : α): M
 
 @[simp]
-def _AbstractFREventSpec.to_AbstractREventSpec [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def _AbstractFREventSpec.to_AbstractREventSpec [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (ev : _AbstractFREventSpec AM M α) : _AbstractREventSpec AM M α :=
   {
     lift := lift
@@ -30,8 +30,8 @@ def _AbstractFREventSpec.to_AbstractREventSpec [Machine ACTX AM] [Machine CTX M]
     unlift := ev.unlift
   }
 
-structure AbstractFREventSpec (AM) [Machine ACTX AM]
-                             (M) [Machine CTX M]
+structure AbstractFREventSpec (AM) [@Machine ACTX AM]
+                             (M) [@Machine CTX M]
                              [FRefinement AM M]
   {α β} (abstract : OrdinaryEvent AM α β)
           extends _AbstractFREventSpec AM M α where
@@ -50,7 +50,7 @@ structure AbstractFREventSpec (AM) [Machine ACTX AM]
       → Machine.invariant (unlift (lift m) am' m x)
 
 @[simp]
-def AbstractFREventSpec.toAbstractREventSpec [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def AbstractFREventSpec.toAbstractREventSpec [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryEvent AM α β) (ev : AbstractFREventSpec AM M abs) : AbstractREventSpec AM M abs :=
   {
     to_AbstractREventSpec := ev.to_AbstractREventSpec
@@ -59,30 +59,30 @@ def AbstractFREventSpec.toAbstractREventSpec [Machine ACTX AM] [Machine CTX M] [
   }
 
 @[simp]
-def newAbstractFREvent [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAbstractFREvent [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryEvent AM α β) (ev : AbstractFREventSpec AM M abs) : OrdinaryREvent AM M α β :=
   newAbstractREvent abs ev.toAbstractREventSpec
 
 @[simp]
-def newAbstractFREvent' [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAbstractFREvent' [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryEvent AM α Unit) (ev : AbstractFREventSpec AM M abs) : OrdinaryREvent AM M α Unit :=
   newAbstractREvent abs ev.toAbstractREventSpec
 
-structure _AbstractFREventSpec'' (AM) [Machine ACTX AM]
-                              (M) [Machine CTX M]
+structure _AbstractFREventSpec'' (AM) [@Machine ACTX AM]
+                              (M) [@Machine CTX M]
                               [FRefinement AM M] where
 
   unlift (am am' : AM) (m : M): M
 
 @[simp]
-def _AbstractFREventSpec''.to_AbstractFREventSpec [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def _AbstractFREventSpec''.to_AbstractFREventSpec [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (ev : _AbstractFREventSpec'' AM M) : _AbstractFREventSpec AM M Unit :=
   {
     unlift := fun am am' m _ => ev.unlift am am' m
   }
 
-structure AbstractFREventSpec'' (AM) [Machine ACTX AM]
-                             (M) [Machine CTX M]
+structure AbstractFREventSpec'' (AM) [@Machine ACTX AM]
+                             (M) [@Machine CTX M]
                              [FRefinement AM M]
   (abstract : OrdinaryEvent AM Unit Unit)
           extends _AbstractFREventSpec'' AM M where
@@ -101,7 +101,7 @@ structure AbstractFREventSpec'' (AM) [Machine ACTX AM]
       → Machine.invariant (unlift (lift m) am' m)
 
 @[simp]
-def AbstractFREventSpec''.toAbstractREventSpec [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def AbstractFREventSpec''.toAbstractREventSpec [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryEvent AM Unit Unit) (ev : AbstractFREventSpec'' AM M abs) : AbstractREventSpec AM M abs :=
   {
     to_AbstractREventSpec := ev.to_AbstractFREventSpec''.to_AbstractFREventSpec.to_AbstractREventSpec
@@ -110,12 +110,12 @@ def AbstractFREventSpec''.toAbstractREventSpec [Machine ACTX AM] [Machine CTX M]
   }
 
 @[simp]
-def newAbstractFREvent'' [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAbstractFREvent'' [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryEvent AM Unit Unit) (ev : AbstractFREventSpec'' AM M abs) : OrdinaryREvent AM M Unit Unit :=
   newAbstractREvent abs ev.toAbstractREventSpec
 
-structure AbstractInitFREventSpec (AM) [Machine ACTX AM]
-                             (M) [Machine CTX M]
+structure AbstractInitFREventSpec (AM) [@Machine ACTX AM]
+                             (M) [@Machine CTX M]
                              [FRefinement AM M]
   {α β} (abstract : InitEvent AM α β)
           extends _AbstractFREventSpec AM M α where
@@ -132,7 +132,7 @@ structure AbstractInitFREventSpec (AM) [Machine ACTX AM]
       → Machine.invariant (unlift default am' default x)
 
 @[simp]
-def AbstractInitFREventSpec.toAbstractInitREventSpec [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def AbstractInitFREventSpec.toAbstractInitREventSpec [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : InitEvent AM α β) (ev : AbstractInitFREventSpec AM M abs) : AbstractInitREventSpec AM M abs :=
   {
     to_AbstractREventSpec := ev.to_AbstractREventSpec
@@ -141,17 +141,17 @@ def AbstractInitFREventSpec.toAbstractInitREventSpec [Machine ACTX AM] [Machine 
   }
 
 @[simp]
-def newAbstractInitFREvent [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAbstractInitFREvent [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : InitEvent AM α β) (ev : AbstractInitFREventSpec AM M abs) : InitREvent AM M α β :=
   newAbstractInitREvent abs ev.toAbstractInitREventSpec
 
 @[simp]
-def newAbstractInitFREvent' [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAbstractInitFREvent' [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : InitEvent AM α Unit) (ev : AbstractInitFREventSpec AM M abs) : InitREvent AM M α Unit :=
   newAbstractInitREvent abs ev.toAbstractInitREventSpec
 
-structure AbstractInitFREventSpec'' (AM) [Machine ACTX AM]
-                             (M) [Machine CTX M]
+structure AbstractInitFREventSpec'' (AM) [@Machine ACTX AM]
+                             (M) [@Machine CTX M]
                              [FRefinement AM M]
   (abstract : InitEvent AM Unit Unit)
           extends _AbstractFREventSpec'' AM M where
@@ -168,7 +168,7 @@ structure AbstractInitFREventSpec'' (AM) [Machine ACTX AM]
       → Machine.invariant (unlift default am' default)
 
 @[simp]
-def AbstractInitFREventSpec''.toAbstractInitFREventSpec [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def AbstractInitFREventSpec''.toAbstractInitFREventSpec [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : InitEvent AM Unit Unit) (ev : AbstractInitFREventSpec'' AM M abs) : AbstractInitFREventSpec AM M abs :=
   {
     to_AbstractFREventSpec := ev.to_AbstractFREventSpec
@@ -177,14 +177,14 @@ def AbstractInitFREventSpec''.toAbstractInitFREventSpec [Machine ACTX AM] [Machi
   }
 
 @[simp]
-def newAbstractInitFREvent'' [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAbstractInitFREvent'' [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : InitEvent AM Unit Unit) (ev : AbstractInitFREventSpec'' AM M abs) : InitREvent AM M Unit Unit :=
   newAbstractInitFREvent abs ev.toAbstractInitFREventSpec
 
 structure AbstractAnticipatedFREventSpec
               (v) [Preorder v]
-              (AM) [Machine ACTX AM]
-              (M) [Machine CTX M]
+              (AM) [@Machine ACTX AM]
+              (M) [@Machine CTX M]
               [FRefinement AM M]
   {α β} (abstract : AnticipatedEvent v AM α β)
           extends AbstractFREventSpec AM M abstract.toOrdinaryEvent where
@@ -198,7 +198,7 @@ structure AbstractAnticipatedFREventSpec
       = abstract.po.variant am'
 
 @[simp]
-def AbstractAnticipatedFREventSpec.toAbstractAnticipatedREventSpec [Preorder v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def AbstractAnticipatedFREventSpec.toAbstractAnticipatedREventSpec [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : AnticipatedEvent v AM α β) (ev : AbstractAnticipatedFREventSpec v AM M abs) : AbstractAnticipatedREventSpec v AM M abs :=
   {
     to_AbstractREventSpec := ev.to_AbstractREventSpec
@@ -208,19 +208,19 @@ def AbstractAnticipatedFREventSpec.toAbstractAnticipatedREventSpec [Preorder v] 
   }
 
 @[simp]
-def newAbstractAnticipatedFREvent  [Preorder v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAbstractAnticipatedFREvent  [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : AnticipatedEvent v AM α β) (ev : AbstractAnticipatedFREventSpec v AM M abs) : AnticipatedREvent v AM M α β :=
   newAbstractAnticipatedREvent abs ev.toAbstractAnticipatedREventSpec
 
 @[simp]
-def newAbstractAnticipatedFREvent'  [Preorder v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAbstractAnticipatedFREvent'  [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : AnticipatedEvent v AM α Unit) (ev : AbstractAnticipatedFREventSpec v AM M abs) : AnticipatedREvent v AM M α Unit :=
   newAbstractAnticipatedREvent abs ev.toAbstractAnticipatedREventSpec
 
 structure AbstractAnticipatedFREventSpec''
               (v) [Preorder v]
-              (AM) [Machine ACTX AM]
-              (M) [Machine CTX M]
+              (AM) [@Machine ACTX AM]
+              (M) [@Machine CTX M]
               [FRefinement AM M]
   (abstract : AnticipatedEvent v AM Unit Unit)
           extends AbstractFREventSpec'' AM M abstract.toOrdinaryEvent where
@@ -234,7 +234,7 @@ structure AbstractAnticipatedFREventSpec''
       = abstract.po.variant am'
 
 @[simp]
-def AbstractAnticipatedFREventSpec''.toAbstractAnticipatedREventSpec [Preorder v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def AbstractAnticipatedFREventSpec''.toAbstractAnticipatedREventSpec [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : AnticipatedEvent v AM Unit Unit) (ev : AbstractAnticipatedFREventSpec'' v AM M abs) : AbstractAnticipatedREventSpec v AM M abs :=
   {
     toAbstractREventSpec := ev.toAbstractFREventSpec''.toAbstractREventSpec
@@ -242,21 +242,21 @@ def AbstractAnticipatedFREventSpec''.toAbstractAnticipatedREventSpec [Preorder v
   }
 
 @[simp]
-def newAbstractAnticipatedFREvent''  [Preorder v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAbstractAnticipatedFREvent''  [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : AnticipatedEvent v AM Unit Unit) (ev : AbstractAnticipatedFREventSpec'' v AM M abs) : AnticipatedREvent v AM M Unit Unit :=
   newAbstractAnticipatedREvent abs ev.toAbstractAnticipatedREventSpec
 
 @[simp]
-def newAbstractConvergentFREvent  [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAbstractConvergentFREvent  [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : ConvergentEvent v AM α β) (ev : AbstractAnticipatedFREventSpec v AM M abs.toAnticipatedEvent) : ConvergentREvent v AM M α β :=
   newAbstractConvergentREvent abs ev.toAbstractAnticipatedREventSpec
 
 @[simp]
-def newAbstractConvergentFREvent'  [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAbstractConvergentFREvent'  [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : ConvergentEvent v AM α Unit) (ev : AbstractAnticipatedFREventSpec v AM M abs.toAnticipatedEvent) : ConvergentREvent v AM M α Unit :=
   newAbstractConvergentREvent abs ev.toAbstractAnticipatedREventSpec
 
 @[simp]
-def newAbstractConvergentFREvent''  [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAbstractConvergentFREvent''  [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : ConvergentEvent v AM Unit Unit) (ev : AbstractAnticipatedFREventSpec'' v AM M abs.toAnticipatedEvent) : ConvergentREvent v AM M Unit Unit :=
   newAbstractConvergentREvent abs ev.toAbstractAnticipatedREventSpec

--- a/LeanMachines/Refinement/Functional/Basic.lean
+++ b/LeanMachines/Refinement/Functional/Basic.lean
@@ -20,7 +20,7 @@ of an abstract machine type `AM` (in context `ACTX`) by
 -/
 class FRefinement {ACTX : outParam (Type u₁)} (AM)
                   {CTX : outParam (Type u₂)} (M)
-                  [Machine ACTX AM] [Machine CTX M] where
+                  [@Machine ACTX AM] [@Machine CTX M] where
   /-- The *lifting* of a concrete state `m` to the abstract level. -/
   lift (m : M): AM
 
@@ -37,7 +37,7 @@ The (somewhat meta-theoretical) proof that functional refinement is preserving
 the relational `Refinement` principles. Technically, any (typeclass) instance
 of a `FRefinement` is also an instance of `Refinement`.
 -/
-instance [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]: Refinement AM M where
+instance [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]: Refinement AM M where
   refine (am : AM) (m : M) := am = lift m
 
   refine_safe (am : AM) (m : M) := by
@@ -47,7 +47,7 @@ instance [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]: Refinement AM M w
     exact lift_safe m Hinv
 
 /-- This theorem allows to go back to the relational refinement level if needed. -/
-theorem lift_ref [Machine ACTX AM] [Machine CTX M] [instFR:FRefinement AM M] (m : M) :
+theorem lift_ref [@Machine ACTX AM] [@Machine CTX M] [instFR:FRefinement AM M] (m : M) :
   Machine.invariant m
   → refine (AM:=AM) (self:=instRefinementOfFRefinement) (lift m) m :=
 by
@@ -66,7 +66,7 @@ cf. the module `Refinement.Refinement.Basic` for further documentation.
 /-- Specification of ordinary refined events.
 cf.  `REventSpec` in relational refinement.
  -/
-structure FREventSpec (AM) [Machine ACTX AM] (M) [Machine CTX M] [instfr: FRefinement AM M]
+structure FREventSpec (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instfr: FRefinement AM M]
   {α β α' β'} (abstract : OrdinaryEvent AM α' β')
   extends EventSpec M α β where
 
@@ -87,7 +87,7 @@ structure FREventSpec (AM) [Machine ACTX AM] (M) [Machine CTX M] [instfr: FRefin
 
 
 @[simp]
-def FREventSpec.toREventSpec [Machine ACTX AM] [Machine CTX M] [instFR: FRefinement AM M]
+def FREventSpec.toREventSpec [@Machine ACTX AM] [@Machine CTX M] [instFR: FRefinement AM M]
   {α β α' β'} (abs : OrdinaryEvent AM α' β')
   (ev : FREventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : REventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abs :=
   {
@@ -114,11 +114,11 @@ def FREventSpec.toREventSpec [Machine ACTX AM] [Machine CTX M] [instFR: FRefinem
   }
 
 @[simp]
-def newFREvent [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newFREvent [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryEvent AM α' β') (ev : FREventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : OrdinaryREvent AM M α β α' β' :=
   newREvent abs ev.toREventSpec
 
-structure FREventSpec' (AM) [Machine ACTX AM] (M) [Machine CTX M] [instfr: FRefinement AM M]
+structure FREventSpec' (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instfr: FRefinement AM M]
   {α α'} (abstract : OrdinaryEvent AM α' Unit)
   extends EventSpec' M α where
 
@@ -137,7 +137,7 @@ structure FREventSpec' (AM) [Machine ACTX AM] (M) [Machine CTX M] [instfr: FRefi
       am' = (lift m')
 
 @[simp]
-def FREventSpec'.toFREventSpec [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def FREventSpec'.toFREventSpec [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   {α α'} (abs : OrdinaryEvent AM α' Unit)
   (ev : FREventSpec' AM M (α:=α) (α':=α') abs) : FREventSpec AM M (α:=α) (β:=Unit) (α':=α') (β':=Unit) abs :=
   {
@@ -149,11 +149,11 @@ def FREventSpec'.toFREventSpec [Machine ACTX AM] [Machine CTX M] [FRefinement AM
   }
 
 @[simp]
-def newFREvent' [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newFREvent' [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryEvent AM α' Unit) (ev : FREventSpec' AM M (α:=α) (α':=α') abs) : OrdinaryREvent AM M α Unit α' Unit :=
   newFREvent abs ev.toFREventSpec
 
-structure FREventSpec'' (AM) [Machine ACTX AM] (M) [Machine CTX M] [instfr: FRefinement AM M]
+structure FREventSpec'' (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instfr: FRefinement AM M]
   (abstract : OrdinaryEvent AM Unit Unit)
   extends EventSpec'' M where
 
@@ -170,7 +170,7 @@ structure FREventSpec'' (AM) [Machine ACTX AM] (M) [Machine CTX M] [instfr: FRef
       am' = (lift m')
 
 @[simp]
-def FREventSpec''.toFREventSpec [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def FREventSpec''.toFREventSpec [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryEvent AM Unit Unit)
   (ev : FREventSpec'' AM M abs) : FREventSpec AM M (α:=Unit) (β:=Unit) (α':=Unit) (β':=Unit) abs :=
   {
@@ -185,14 +185,14 @@ def FREventSpec''.toFREventSpec [Machine ACTX AM] [Machine CTX M] [FRefinement A
   }
 
 @[simp]
-def newFREvent'' [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newFREvent'' [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryEvent AM Unit Unit) (ev : FREventSpec'' AM M abs) : OrdinaryREvent AM M Unit Unit :=
   newFREvent abs ev.toFREventSpec
 
 
 /- Initialization events -/
 
-structure InitFREventSpec (AM) [Machine ACTX AM] (M) [Machine CTX M] [instFR: FRefinement AM M]
+structure InitFREventSpec (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instFR: FRefinement AM M]
   {α β α' β'} (abstract : InitEvent AM α' β')
   extends InitEventSpec M α β where
 
@@ -210,7 +210,7 @@ structure InitFREventSpec (AM) [Machine ACTX AM] (M) [Machine CTX M] [instFR: FR
       lift_out y = z ∧ am' = lift m'
 
 @[simp]
-def InitFREventSpec.toInitREventSpec [Machine ACTX AM] [Machine CTX M] [instFR: FRefinement AM M]
+def InitFREventSpec.toInitREventSpec [@Machine ACTX AM] [@Machine CTX M] [instFR: FRefinement AM M]
   {abs : InitEvent AM α' β'}
   (ev : InitFREventSpec (AM:=AM) (M:=M) (instFR:=instFR) (α:=α) (β:=β) (α':=α') (β':=β') abs)
     : InitREventSpec (AM:=AM) (M:=M) (α:=α) (β:=β) (α':=α') (β':=β') abs :=
@@ -230,11 +230,11 @@ def InitFREventSpec.toInitREventSpec [Machine ACTX AM] [Machine CTX M] [instFR: 
   }
 
 @[simp]
-def newInitFREvent [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newInitFREvent [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : InitEvent AM α' β') (ev : InitFREventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : InitREvent AM M α β α' β' :=
   newInitREvent abs ev.toInitREventSpec
 
-structure InitFREventSpec' (AM) [Machine ACTX AM] (M) [Machine CTX M] [instFR: FRefinement AM M]
+structure InitFREventSpec' (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instFR: FRefinement AM M]
   {α α'} (abstract : InitEvent AM α' Unit)
   extends InitEventSpec' M α where
 
@@ -251,7 +251,7 @@ structure InitFREventSpec' (AM) [Machine ACTX AM] (M) [Machine CTX M] [instFR: F
       am' = lift m'
 
 @[simp]
-def InitFREventSpec'.toInitFREventSpec [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def InitFREventSpec'.toInitFREventSpec [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   {α α'} (abs : InitEvent AM α' Unit)
   (ev : InitFREventSpec' AM M (α:=α) (α':=α') abs) : InitFREventSpec AM M (α:=α) (β:=Unit) (α':=α') (β':=Unit) abs :=
   {
@@ -266,11 +266,11 @@ def InitFREventSpec'.toInitFREventSpec [Machine ACTX AM] [Machine CTX M] [FRefin
   }
 
 @[simp]
-def newInitFREvent' [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newInitFREvent' [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : InitEvent AM α' Unit) (ev : InitFREventSpec' AM M (α:=α) (α':=α') abs) : InitREvent AM M α Unit α' Unit :=
   newInitFREvent abs ev.toInitFREventSpec
 
-structure InitFREventSpec'' (AM) [Machine ACTX AM] (M) [Machine CTX M] [instFR: FRefinement AM M]
+structure InitFREventSpec'' (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instFR: FRefinement AM M]
   (abstract : InitEvent AM Unit Unit)
   extends InitEventSpec'' M where
 
@@ -285,7 +285,7 @@ structure InitFREventSpec'' (AM) [Machine ACTX AM] (M) [Machine CTX M] [instFR: 
       am' = lift m'
 
 @[simp]
-def InitFREventSpec''.toInitFREventSpec [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def InitFREventSpec''.toInitFREventSpec [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : InitEvent AM Unit Unit)
   (ev : InitFREventSpec'' AM M abs) : InitFREventSpec AM M (α:=Unit) (β:=Unit) (α':=Unit) (β':=Unit) abs :=
   {
@@ -300,6 +300,6 @@ def InitFREventSpec''.toInitFREventSpec [Machine ACTX AM] [Machine CTX M] [FRefi
   }
 
 @[simp]
-def newInitFREvent'' [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newInitFREvent'' [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : InitEvent AM Unit Unit) (ev : InitFREventSpec'' AM M abs) : InitREvent AM M Unit Unit :=
   newInitFREvent abs ev.toInitFREventSpec

--- a/LeanMachines/Refinement/Functional/Concrete.lean
+++ b/LeanMachines/Refinement/Functional/Concrete.lean
@@ -5,7 +5,7 @@ import LeanMachines.Refinement.Relational.Concrete
 open Refinement
 open FRefinement
 
-structure ConcreteFREventSpec (AM) [Machine ACTX AM] (M) [Machine CTX M] [instFR: FRefinement AM M] (α) (β)
+structure ConcreteFREventSpec (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instFR: FRefinement AM M] (α) (β)
   extends EventSpec M α β where
 
   simulation (m : M) (x : α):
@@ -15,7 +15,7 @@ structure ConcreteFREventSpec (AM) [Machine ACTX AM] (M) [Machine CTX M] [instFR
       lift m = lift (self:=instFR)  m'
 
 @[simp]
-def ConcreteFREventSpec.toConcreteREventSpec  [Machine ACTX AM] [Machine CTX M] [instFR: FRefinement AM M]
+def ConcreteFREventSpec.toConcreteREventSpec  [@Machine ACTX AM] [@Machine CTX M] [instFR: FRefinement AM M]
   (ev : ConcreteFREventSpec AM M α β) : ConcreteREventSpec AM M α β :=
   {
     toEventSpec := ev.toEventSpec
@@ -29,11 +29,11 @@ def ConcreteFREventSpec.toConcreteREventSpec  [Machine ACTX AM] [Machine CTX M] 
   }
 
 @[simp]
-def newConcreteFREvent [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newConcreteFREvent [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
    (ev : ConcreteFREventSpec AM M α β) : OrdinaryRDetEvent AM M α β :=
   newConcreteREvent ev.toConcreteREventSpec
 
-structure ConcreteFREventSpec' (AM) [Machine ACTX AM] (M) [Machine CTX M] [instFR: FRefinement AM M] (α)
+structure ConcreteFREventSpec' (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instFR: FRefinement AM M] (α)
   extends EventSpec' M α where
 
   simulation (m : M) (x : α):
@@ -43,7 +43,7 @@ structure ConcreteFREventSpec' (AM) [Machine ACTX AM] (M) [Machine CTX M] [instF
       lift m = lift (self:=instFR)  m'
 
 @[simp]
-def ConcreteFREventSpec'.toConcreteFREventSpec  [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def ConcreteFREventSpec'.toConcreteFREventSpec  [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (ev : ConcreteFREventSpec' AM M α) : ConcreteFREventSpec AM M α Unit :=
   {
     toEventSpec := ev.toEventSpec
@@ -51,11 +51,11 @@ def ConcreteFREventSpec'.toConcreteFREventSpec  [Machine ACTX AM] [Machine CTX M
   }
 
 @[simp]
-def newConcreteFREvent' [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newConcreteFREvent' [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
    (ev : ConcreteFREventSpec' AM M α) : OrdinaryRDetEvent AM M α Unit :=
   newConcreteREvent ev.toConcreteFREventSpec.toConcreteREventSpec
 
-structure ConcreteFREventSpec'' (AM) [Machine ACTX AM] (M) [Machine CTX M] [instFR: FRefinement AM M]
+structure ConcreteFREventSpec'' (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instFR: FRefinement AM M]
   extends EventSpec'' M where
 
   simulation (m : M):
@@ -65,7 +65,7 @@ structure ConcreteFREventSpec'' (AM) [Machine ACTX AM] (M) [Machine CTX M] [inst
       lift m = lift (self:=instFR)  m'
 
 @[simp]
-def ConcreteFREventSpec''.toConcreteFREventSpec [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def ConcreteFREventSpec''.toConcreteFREventSpec [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (ev : ConcreteFREventSpec'' AM M) : ConcreteFREventSpec AM M Unit Unit :=
   {
     toEventSpec := ev.toEventSpec
@@ -73,13 +73,13 @@ def ConcreteFREventSpec''.toConcreteFREventSpec [Machine ACTX AM] [Machine CTX M
   }
 
 @[simp]
-def newConcreteFREvent'' [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newConcreteFREvent'' [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
    (ev : ConcreteFREventSpec'' AM M) : OrdinaryRDetEvent AM M Unit Unit :=
   newConcreteREvent ev.toConcreteFREventSpec.toConcreteREventSpec
 
 /- Anticipated concrete events -/
 
-structure ConcreteAnticipatedFREventSpec (v) [Preorder v] [WellFoundedLT v] (AM) [Machine ACTX AM] (M) [Machine CTX M] [instFR: FRefinement AM M] (α) (β)
+structure ConcreteAnticipatedFREventSpec (v) [Preorder v] [WellFoundedLT v] (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instFR: FRefinement AM M] (α) (β)
   extends _Variant (M:=M) v, ConcreteFREventSpec AM M α β where
 
   nonIncreasing (m : M) (x : α):
@@ -89,7 +89,7 @@ structure ConcreteAnticipatedFREventSpec (v) [Preorder v] [WellFoundedLT v] (AM)
       variant m' ≤ variant m
 
 @[simp]
-def ConcreteAnticipatedFREventSpec.toConcreteAnticipatedREventSpec  [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def ConcreteAnticipatedFREventSpec.toConcreteAnticipatedREventSpec  [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (ev : ConcreteAnticipatedFREventSpec v AM M α β) : ConcreteAnticipatedREventSpec v AM M α β :=
   {
     toEventSpec := ev.toEventSpec
@@ -100,11 +100,11 @@ def ConcreteAnticipatedFREventSpec.toConcreteAnticipatedREventSpec  [Preorder v]
 
 @[simp]
 def newConcreteAnticipatedFREvent [Preorder v] [WellFoundedLT v]
-                        [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+                        [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
    (ev : ConcreteAnticipatedFREventSpec v AM M α β) : AnticipatedRDetEvent v AM M α β :=
   newConcreteAnticipatedREvent ev.toConcreteAnticipatedREventSpec
 
-structure ConcreteAnticipatedFREventSpec' (v) [Preorder v] [WellFoundedLT v] (AM) [Machine ACTX AM] (M) [Machine CTX M] [instFR: FRefinement AM M] (α)
+structure ConcreteAnticipatedFREventSpec' (v) [Preorder v] [WellFoundedLT v] (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instFR: FRefinement AM M] (α)
   extends _Variant (M:=M) v, ConcreteREventSpec' AM M α where
 
   nonIncreasing (m : M) (x : α):
@@ -114,7 +114,7 @@ structure ConcreteAnticipatedFREventSpec' (v) [Preorder v] [WellFoundedLT v] (AM
       variant m' ≤ variant m
 
 @[simp]
-def ConcreteAnticipatedFREventSpec'.toConcreteAnticipatedREventSpec  [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def ConcreteAnticipatedFREventSpec'.toConcreteAnticipatedREventSpec  [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (ev : ConcreteAnticipatedFREventSpec' v AM M α) : ConcreteAnticipatedREventSpec v AM M α Unit :=
   {
     toEventSpec := ev.toEventSpec
@@ -125,11 +125,11 @@ def ConcreteAnticipatedFREventSpec'.toConcreteAnticipatedREventSpec  [Preorder v
 
 @[simp]
 def newConcreteAnticipatedFREvent' [Preorder v] [WellFoundedLT v]
-                        [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+                        [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
    (ev : ConcreteAnticipatedFREventSpec' v AM M α) : AnticipatedRDetEvent v AM M α Unit :=
   newConcreteAnticipatedREvent ev.toConcreteAnticipatedREventSpec
 
-structure ConcreteAnticipatedFREventSpec'' (v) [Preorder v] [WellFoundedLT v] (AM) [Machine ACTX AM] (M) [Machine CTX M] [instFR: FRefinement AM M]
+structure ConcreteAnticipatedFREventSpec'' (v) [Preorder v] [WellFoundedLT v] (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instFR: FRefinement AM M]
   extends _Variant (M:=M) v, ConcreteFREventSpec'' AM M where
 
   nonIncreasing (m : M):
@@ -139,7 +139,7 @@ structure ConcreteAnticipatedFREventSpec'' (v) [Preorder v] [WellFoundedLT v] (A
       variant m' ≤ variant m
 
 @[simp]
-def ConcreteAnticipatedFREventSpec''.toConcreteAnticipatedFREventSpec  [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def ConcreteAnticipatedFREventSpec''.toConcreteAnticipatedFREventSpec  [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (ev : ConcreteAnticipatedFREventSpec'' v AM M) : ConcreteAnticipatedFREventSpec v AM M Unit Unit :=
   {
     toEventSpec := ev.toEventSpec
@@ -150,13 +150,13 @@ def ConcreteAnticipatedFREventSpec''.toConcreteAnticipatedFREventSpec  [Preorder
 
 @[simp]
 def newConcreteAnticipatedFREvent'' [Preorder v] [WellFoundedLT v]
-                         [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+                         [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
    (ev : ConcreteAnticipatedFREventSpec'' v AM M) : AnticipatedRDetEvent v AM M Unit Unit :=
   newConcreteAnticipatedREvent ev.toConcreteAnticipatedFREventSpec.toConcreteAnticipatedREventSpec
 
 /- Convergent concrete events -/
 
-structure ConcreteConvergentFREventSpec (v) [Preorder v] [WellFoundedLT v] (AM) [Machine ACTX AM] (M) [Machine CTX M] [instFR: FRefinement AM M] (α) (β)
+structure ConcreteConvergentFREventSpec (v) [Preorder v] [WellFoundedLT v] (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instFR: FRefinement AM M] (α) (β)
   extends _Variant (M:=M) v, ConcreteFREventSpec AM M α β where
 
   convergence (m : M) (x : α):
@@ -166,7 +166,7 @@ structure ConcreteConvergentFREventSpec (v) [Preorder v] [WellFoundedLT v] (AM) 
       variant m' < variant m
 
 @[simp]
-def ConcreteConvergentFREventSpec.toConcreteConvergentREventSpec  [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def ConcreteConvergentFREventSpec.toConcreteConvergentREventSpec  [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (ev : ConcreteConvergentFREventSpec v AM M α β) : ConcreteConvergentREventSpec v AM M α β :=
   {
     toEventSpec := ev.toEventSpec
@@ -177,11 +177,11 @@ def ConcreteConvergentFREventSpec.toConcreteConvergentREventSpec  [Preorder v] [
 
 @[simp]
 def newConcreteConvergentFREvent [Preorder v] [WellFoundedLT v]
-                        [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+                        [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
    (ev : ConcreteConvergentFREventSpec v AM M α β) : ConvergentRDetEvent v AM M α β :=
   newConcreteConvergentREvent ev.toConcreteConvergentREventSpec
 
-structure ConcreteConvergentFREventSpec' (v) [Preorder v] [WellFoundedLT v] (AM) [Machine ACTX AM] (M) [Machine CTX M] [instFR: FRefinement AM M] (α)
+structure ConcreteConvergentFREventSpec' (v) [Preorder v] [WellFoundedLT v] (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instFR: FRefinement AM M] (α)
   extends _Variant (M:=M) v, ConcreteREventSpec' AM M α where
 
   convergence (m : M) (x : α):
@@ -191,7 +191,7 @@ structure ConcreteConvergentFREventSpec' (v) [Preorder v] [WellFoundedLT v] (AM)
       variant m' < variant m
 
 @[simp]
-def ConcreteConvergentFREventSpec'.toConcreteConvergentREventSpec  [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def ConcreteConvergentFREventSpec'.toConcreteConvergentREventSpec  [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (ev : ConcreteConvergentFREventSpec' v AM M α) : ConcreteConvergentREventSpec v AM M α Unit :=
   {
     toEventSpec := ev.toEventSpec
@@ -202,11 +202,11 @@ def ConcreteConvergentFREventSpec'.toConcreteConvergentREventSpec  [Preorder v] 
 
 @[simp]
 def newConcreteConvergentFREvent' [Preorder v] [WellFoundedLT v]
-                        [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+                        [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
    (ev : ConcreteConvergentFREventSpec' v AM M α) : ConvergentRDetEvent v AM M α Unit :=
   newConcreteConvergentREvent ev.toConcreteConvergentREventSpec
 
-structure ConcreteConvergentFREventSpec'' (v) [Preorder v] [WellFoundedLT v] (AM) [Machine ACTX AM] (M) [Machine CTX M] [instFR: FRefinement AM M]
+structure ConcreteConvergentFREventSpec'' (v) [Preorder v] [WellFoundedLT v] (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instFR: FRefinement AM M]
   extends _Variant (M:=M) v, ConcreteFREventSpec'' AM M where
 
   convergence (m : M):
@@ -216,7 +216,7 @@ structure ConcreteConvergentFREventSpec'' (v) [Preorder v] [WellFoundedLT v] (AM
       variant m' < variant m
 
 @[simp]
-def ConcreteConvergentFREventSpec''.toConcreteConvergentFREventSpec  [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def ConcreteConvergentFREventSpec''.toConcreteConvergentFREventSpec  [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (ev : ConcreteConvergentFREventSpec'' v AM M) : ConcreteConvergentFREventSpec v AM M Unit Unit :=
   {
     toEventSpec := ev.toEventSpec
@@ -227,6 +227,6 @@ def ConcreteConvergentFREventSpec''.toConcreteConvergentFREventSpec  [Preorder v
 
 @[simp]
 def newConcreteConvergentFREvent'' [Preorder v] [WellFoundedLT v]
-                         [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+                         [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
    (ev : ConcreteConvergentFREventSpec'' v AM M) : ConvergentRDetEvent v AM M Unit Unit :=
   newConcreteConvergentREvent ev.toConcreteConvergentFREventSpec.toConcreteConvergentREventSpec

--- a/LeanMachines/Refinement/Functional/Convergent.lean
+++ b/LeanMachines/Refinement/Functional/Convergent.lean
@@ -6,7 +6,7 @@ import LeanMachines.Event.Convergent
 open Refinement
 open FRefinement
 
-structure AnticipatedFREventSpec (v) [Preorder v] (AM) [Machine ACTX AM] (M) [instM:Machine CTX M] [FRefinement AM M]
+structure AnticipatedFREventSpec (v) [Preorder v] (AM) [@Machine ACTX AM] (M) [instM:@Machine CTX M] [FRefinement AM M]
   {α β α' β'} (abs : OrdinaryEvent AM α' β')
   extends _Variant v (instM:=instM), FREventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abs where
 
@@ -17,7 +17,7 @@ structure AnticipatedFREventSpec (v) [Preorder v] (AM) [Machine ACTX AM] (M) [in
       variant m' ≤ variant m
 
 @[simp]
-def AnticipatedFREventSpec.toAnticipatedREventSpec [Preorder v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def AnticipatedFREventSpec.toAnticipatedREventSpec [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryEvent AM α' β') (ev :  AnticipatedFREventSpec v AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : AnticipatedREventSpec v AM M (α:=α) (β:=β) (α':=α') (β':=β') abs :=
   {
     toREventSpec := ev.toREventSpec
@@ -26,11 +26,11 @@ def AnticipatedFREventSpec.toAnticipatedREventSpec [Preorder v] [Machine ACTX AM
   }
 
 @[simp]
-def newAnticipatedFREventfromOrdinary [Preorder v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAnticipatedFREventfromOrdinary [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryEvent AM α' β') (ev : AnticipatedFREventSpec v AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : AnticipatedREvent v AM M α β α' β' :=
   newAnticipatedREventfromOrdinary abs ev.toAnticipatedREventSpec
 
-structure AnticipatedFREventSpec' (v) [Preorder v] (AM) [Machine ACTX AM] (M) [instM:Machine CTX M] [FRefinement AM M]
+structure AnticipatedFREventSpec' (v) [Preorder v] (AM) [@Machine ACTX AM] (M) [instM:@Machine CTX M] [FRefinement AM M]
   {α α'} (abs : OrdinaryEvent AM α' Unit)
   extends _Variant v (instM:=instM), FREventSpec' AM M (α:=α) (α':=α') abs where
 
@@ -41,7 +41,7 @@ structure AnticipatedFREventSpec' (v) [Preorder v] (AM) [Machine ACTX AM] (M) [i
       variant m' ≤ variant m
 
 @[simp]
-def AnticipatedFREventSpec'.toAnticipatedFREventSpec [Preorder v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def AnticipatedFREventSpec'.toAnticipatedFREventSpec [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryEvent AM α' Unit) (ev :  AnticipatedFREventSpec' v AM M (α:=α) (α':=α') abs) : AnticipatedFREventSpec v AM M (α:=α) (β:=Unit) (α':=α') (β':=Unit) abs :=
   {
     toFREventSpec := ev.toFREventSpec
@@ -50,11 +50,11 @@ def AnticipatedFREventSpec'.toAnticipatedFREventSpec [Preorder v] [Machine ACTX 
   }
 
 @[simp]
-def newAnticipatedFREventfromOrdinary' [Preorder v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAnticipatedFREventfromOrdinary' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryEvent AM α' Unit) (ev : AnticipatedFREventSpec' v AM M (α:=α) (α':=α') abs) : AnticipatedREvent v AM M α Unit α' Unit :=
   newAnticipatedFREventfromOrdinary abs ev.toAnticipatedFREventSpec
 
-structure AnticipatedFREventSpec'' (v) [Preorder v] (AM) [Machine ACTX AM] (M) [instM:Machine CTX M] [FRefinement AM M]
+structure AnticipatedFREventSpec'' (v) [Preorder v] (AM) [@Machine ACTX AM] (M) [instM:@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryEvent AM Unit Unit)
   extends _Variant v (instM:=instM), FREventSpec'' AM M abs where
 
@@ -65,7 +65,7 @@ structure AnticipatedFREventSpec'' (v) [Preorder v] (AM) [Machine ACTX AM] (M) [
       variant m' ≤ variant m
 
 @[simp]
-def AnticipatedFREventSpec''.toAnticipatedFREventSpec [Preorder v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def AnticipatedFREventSpec''.toAnticipatedFREventSpec [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryEvent AM Unit Unit) (ev :  AnticipatedFREventSpec'' v AM M abs) : AnticipatedFREventSpec v AM M (α:=Unit) (β:=Unit) (α':=Unit) (β':=Unit) abs :=
   {
     toFREventSpec := ev.toFREventSpec
@@ -74,26 +74,26 @@ def AnticipatedFREventSpec''.toAnticipatedFREventSpec [Preorder v] [Machine ACTX
   }
 
 @[simp]
-def newAnticipatedFREventfromOrdinary'' [Preorder v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAnticipatedFREventfromOrdinary'' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryEvent AM Unit Unit) (ev : AnticipatedFREventSpec'' v AM M abs) : AnticipatedREvent v AM M Unit Unit :=
   newAnticipatedFREventfromOrdinary abs ev.toAnticipatedFREventSpec
 
 @[simp]
-def newAnticipatedFREventfromAnticipated [Preorder v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAnticipatedFREventfromAnticipated [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : AnticipatedEvent v AM α' β') (ev : AnticipatedFREventSpec v AM M (α:=α) (β:=β) (α':=α') (β':=β') abs.toOrdinaryEvent) : AnticipatedREvent v AM M α β α' β' :=
   newAnticipatedREventfromAnticipated abs ev.toAnticipatedREventSpec
 
 @[simp]
-def newAnticipatedFREventfromAnticipated' [Preorder v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAnticipatedFREventfromAnticipated' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : AnticipatedEvent v AM α' Unit) (ev : AnticipatedFREventSpec' v AM M (α:=α) (α':=α') abs.toOrdinaryEvent) : AnticipatedREvent v AM M α Unit α' Unit :=
   newAnticipatedFREventfromAnticipated abs ev.toAnticipatedFREventSpec
 
 @[simp]
-def newAnticipatedFREventfromAnticipated'' [Preorder v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAnticipatedFREventfromAnticipated'' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : AnticipatedEvent v AM Unit Unit) (ev : AnticipatedFREventSpec'' v AM M abs.toOrdinaryEvent) : AnticipatedREvent v AM M Unit Unit :=
   newAnticipatedFREventfromAnticipated abs ev.toAnticipatedFREventSpec
 
-structure ConvergentFREventSpec (v) [Preorder v] [WellFoundedLT v] (AM) [Machine ACTX AM] (M) [instM:Machine CTX M] [FRefinement AM M]
+structure ConvergentFREventSpec (v) [Preorder v] [WellFoundedLT v] (AM) [@Machine ACTX AM] (M) [instM:@Machine CTX M] [FRefinement AM M]
   {α β α' β'} (abs : OrdinaryEvent AM α' β')
   extends _Variant v (instM:=instM), FREventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abs where
 
@@ -104,7 +104,7 @@ structure ConvergentFREventSpec (v) [Preorder v] [WellFoundedLT v] (AM) [Machine
       variant m' < variant m
 
 @[simp]
-def ConvergentFREventSpec.toConvergentREventSpec [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def ConvergentFREventSpec.toConvergentREventSpec [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryEvent AM α' β') (ev :  ConvergentFREventSpec v AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : ConvergentREventSpec v AM M (α:=α) (β:=β) (α':=α') (β':=β') abs :=
   {
     toREventSpec := ev.toREventSpec
@@ -113,11 +113,11 @@ def ConvergentFREventSpec.toConvergentREventSpec [Preorder v] [WellFoundedLT v] 
   }
 
 @[simp]
-def newConvergentFREvent [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newConvergentFREvent [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryEvent AM α' β') (ev : ConvergentFREventSpec v AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : ConvergentREvent v AM M α β α' β' :=
   newConvergentREvent abs ev.toConvergentREventSpec
 
-structure ConvergentFREventSpec' (v) [Preorder v] [WellFoundedLT v] (AM) [Machine ACTX AM] (M) [instM:Machine CTX M] [FRefinement AM M]
+structure ConvergentFREventSpec' (v) [Preorder v] [WellFoundedLT v] (AM) [@Machine ACTX AM] (M) [instM:@Machine CTX M] [FRefinement AM M]
   {α α'} (abs : OrdinaryEvent AM α' Unit)
   extends _Variant v (instM:=instM), FREventSpec' AM M (α:=α) (α':=α') abs where
 
@@ -128,7 +128,7 @@ structure ConvergentFREventSpec' (v) [Preorder v] [WellFoundedLT v] (AM) [Machin
       variant m' < variant m
 
 @[simp]
-def ConvergentFREventSpec'.toConvergentFREventSpec [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def ConvergentFREventSpec'.toConvergentFREventSpec [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryEvent AM α' Unit) (ev :  ConvergentFREventSpec' v AM M (α:=α) (α':=α') abs) : ConvergentFREventSpec v AM M (α:=α) (β:=Unit) (α':=α') (β':=Unit) abs :=
   {
     toFREventSpec := ev.toFREventSpec
@@ -137,11 +137,11 @@ def ConvergentFREventSpec'.toConvergentFREventSpec [Preorder v] [WellFoundedLT v
   }
 
 @[simp]
-def newConvergentFREvent' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newConvergentFREvent' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryEvent AM α' Unit) (ev : ConvergentFREventSpec' v AM M (α:=α) (α':=α') abs) : ConvergentREvent v AM M α Unit α' Unit :=
   newConvergentFREvent abs ev.toConvergentFREventSpec
 
-structure ConvergentFREventSpec'' (v) [Preorder v] [WellFoundedLT v] (AM) [Machine ACTX AM] (M) [instM:Machine CTX M] [FRefinement AM M]
+structure ConvergentFREventSpec'' (v) [Preorder v] [WellFoundedLT v] (AM) [@Machine ACTX AM] (M) [instM:@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryEvent AM Unit Unit)
   extends _Variant v (instM:=instM), FREventSpec'' AM M abs where
 
@@ -152,7 +152,7 @@ structure ConvergentFREventSpec'' (v) [Preorder v] [WellFoundedLT v] (AM) [Machi
       variant m' < variant m
 
 @[simp]
-def ConvergentFREventSpec''.toConvergentFREventSpec [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def ConvergentFREventSpec''.toConvergentFREventSpec [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryEvent AM Unit Unit) (ev :  ConvergentFREventSpec'' v AM M abs) : ConvergentFREventSpec v AM M (α:=Unit) (β:=Unit) (α':=Unit) (β':=Unit) abs :=
   {
     toFREventSpec := ev.toFREventSpec
@@ -161,6 +161,6 @@ def ConvergentFREventSpec''.toConvergentFREventSpec [Preorder v] [WellFoundedLT 
   }
 
 @[simp]
-def newConvergentFREvent'' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newConvergentFREvent'' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryEvent AM Unit Unit) (ev : ConvergentFREventSpec'' v AM M abs) : ConvergentREvent v AM M Unit Unit :=
   newConvergentFREvent abs ev.toConvergentFREventSpec

--- a/LeanMachines/Refinement/Functional/NonDet/Abstract.lean
+++ b/LeanMachines/Refinement/Functional/NonDet/Abstract.lean
@@ -10,8 +10,8 @@ import LeanMachines.Refinement.Relational.NonDet.Abstract
 open Refinement
 open FRefinement
 
-structure AbstractFRNDEventSpec (AM) [Machine ACTX AM]
-                             (M) [Machine CTX M]
+structure AbstractFRNDEventSpec (AM) [@Machine ACTX AM]
+                             (M) [@Machine CTX M]
                              [FRefinement AM M]
   {α β} (abstract : OrdinaryNDEvent AM α β)
           extends _AbstractFREventSpec AM M α where
@@ -33,7 +33,7 @@ structure AbstractFRNDEventSpec (AM) [Machine ACTX AM]
     → lift (unlift am am' m x) = am'
 
 @[simp]
-def AbstractFRNDEventSpec.toAbstractRNDEventSpec [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def AbstractFRNDEventSpec.toAbstractRNDEventSpec [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryNDEvent AM α β) (ev : AbstractFRNDEventSpec AM M abs) : AbstractRNDEventSpec AM M abs :=
   {
     to_AbstractREventSpec := ev.to_AbstractREventSpec
@@ -43,12 +43,12 @@ def AbstractFRNDEventSpec.toAbstractRNDEventSpec [Machine ACTX AM] [Machine CTX 
   }
 
 @[simp]
-def newAbstractFRNDEvent [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAbstractFRNDEvent [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryNDEvent AM α β) (ev : AbstractFRNDEventSpec AM M abs) : OrdinaryRNDEvent AM M α β :=
   newAbstractRNDEvent abs ev.toAbstractRNDEventSpec
 
-structure AbstractFRNDEventSpec' (AM) [Machine ACTX AM]
-                             (M) [Machine CTX M]
+structure AbstractFRNDEventSpec' (AM) [@Machine ACTX AM]
+                             (M) [@Machine CTX M]
                              [FRefinement AM M]
   {α} (abstract : OrdinaryNDEvent AM α Unit)
           extends _AbstractFREventSpec AM M α where
@@ -70,7 +70,7 @@ structure AbstractFRNDEventSpec' (AM) [Machine ACTX AM]
     → lift (unlift am am' m x) = am'
 
 @[simp]
-def AbstractFRNDEventSpec'.toAbstractFRNDEventSpec [Machine ACTX AM] [Machine CTX M] [instFR: FRefinement AM M]
+def AbstractFRNDEventSpec'.toAbstractFRNDEventSpec [@Machine ACTX AM] [@Machine CTX M] [instFR: FRefinement AM M]
   (abs : OrdinaryNDEvent AM α Unit) (ev : AbstractFRNDEventSpec' AM M abs) : AbstractFRNDEventSpec AM M abs :=
   {
     to_AbstractFREventSpec := ev.to_AbstractFREventSpec
@@ -86,12 +86,12 @@ def AbstractFRNDEventSpec'.toAbstractFRNDEventSpec [Machine ACTX AM] [Machine CT
   }
 
 @[simp]
-def newAbstractFRNDEvent' [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAbstractFRNDEvent' [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryNDEvent AM α Unit) (ev : AbstractFRNDEventSpec' AM M abs) : OrdinaryRNDEvent AM M α Unit :=
   newAbstractFRNDEvent abs ev.toAbstractFRNDEventSpec
 
-structure AbstractFRNDEventSpec'' (AM) [Machine ACTX AM]
-                             (M) [Machine CTX M]
+structure AbstractFRNDEventSpec'' (AM) [@Machine ACTX AM]
+                             (M) [@Machine CTX M]
                              [FRefinement AM M]
   (abstract : OrdinaryNDEvent AM Unit Unit)
           extends _AbstractFREventSpec'' AM M where
@@ -113,7 +113,7 @@ structure AbstractFRNDEventSpec'' (AM) [Machine ACTX AM]
     → lift (unlift am am' m) = am'
 
 @[simp]
-def AbstractFRNDEventSpec''.toAbstractFRNDEventSpec [Machine ACTX AM] [Machine CTX M] [instFR: FRefinement AM M]
+def AbstractFRNDEventSpec''.toAbstractFRNDEventSpec [@Machine ACTX AM] [@Machine CTX M] [instFR: FRefinement AM M]
   (abs : OrdinaryNDEvent AM Unit Unit) (ev : AbstractFRNDEventSpec'' AM M abs) : AbstractFRNDEventSpec AM M abs :=
   {
     to_AbstractFREventSpec := ev.to_AbstractFREventSpec
@@ -129,12 +129,12 @@ def AbstractFRNDEventSpec''.toAbstractFRNDEventSpec [Machine ACTX AM] [Machine C
   }
 
 @[simp]
-def newAbstractFRNDEvent'' [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAbstractFRNDEvent'' [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryNDEvent AM Unit Unit) (ev : AbstractFRNDEventSpec'' AM M abs) : OrdinaryRNDEvent AM M Unit Unit :=
   newAbstractFRNDEvent abs ev.toAbstractFRNDEventSpec
 
-structure AbstractInitFRNDEventSpec (AM) [Machine ACTX AM]
-                             (M) [Machine CTX M]
+structure AbstractInitFRNDEventSpec (AM) [@Machine ACTX AM]
+                             (M) [@Machine CTX M]
                              [FRefinement AM M]
   {α β} (abstract : InitNDEvent AM α β)
           extends _AbstractFREventSpec AM M α where
@@ -154,7 +154,7 @@ structure AbstractInitFRNDEventSpec (AM) [Machine ACTX AM]
     → lift (unlift default am' default x) = am'
 
 @[simp]
-def AbstractInitFRNDEventSpec.toAbstractInitRNDEventSpec [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def AbstractInitFRNDEventSpec.toAbstractInitRNDEventSpec [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : InitNDEvent AM α β) (ev : AbstractInitFRNDEventSpec AM M abs) : AbstractInitRNDEventSpec AM M abs :=
   {
     to_AbstractREventSpec := ev.to_AbstractREventSpec
@@ -164,12 +164,12 @@ def AbstractInitFRNDEventSpec.toAbstractInitRNDEventSpec [Machine ACTX AM] [Mach
   }
 
 @[simp]
-def newAbstractInitFRNDEvent [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAbstractInitFRNDEvent [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : InitNDEvent AM α β) (ev : AbstractInitFRNDEventSpec AM M abs) : InitRNDEvent AM M α β :=
   newAbstractInitRNDEvent abs ev.toAbstractInitRNDEventSpec
 
-structure AbstractInitFRNDEventSpec' (AM) [Machine ACTX AM]
-                             (M) [Machine CTX M]
+structure AbstractInitFRNDEventSpec' (AM) [@Machine ACTX AM]
+                             (M) [@Machine CTX M]
                              [FRefinement AM M]
   {α} (abstract : InitNDEvent AM α Unit)
           extends _AbstractFREventSpec AM M α where
@@ -189,7 +189,7 @@ structure AbstractInitFRNDEventSpec' (AM) [Machine ACTX AM]
     → lift (unlift default am' default x) = am'
 
 @[simp]
-def AbstractInitFRNDEventSpec'.toAbstractInitFRNDEventSpec [Machine ACTX AM] [Machine CTX M] [instFR: FRefinement AM M]
+def AbstractInitFRNDEventSpec'.toAbstractInitFRNDEventSpec [@Machine ACTX AM] [@Machine CTX M] [instFR: FRefinement AM M]
   (abs : InitNDEvent AM α Unit) (ev : AbstractInitFRNDEventSpec' AM M abs) : AbstractInitFRNDEventSpec AM M abs :=
   {
     to_AbstractFREventSpec := ev.to_AbstractFREventSpec
@@ -205,12 +205,12 @@ def AbstractInitFRNDEventSpec'.toAbstractInitFRNDEventSpec [Machine ACTX AM] [Ma
   }
 
 @[simp]
-def newAbstractInitFRNDEvent' [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAbstractInitFRNDEvent' [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : InitNDEvent AM α Unit) (ev : AbstractInitFRNDEventSpec' AM M abs) : InitRNDEvent AM M α Unit :=
   newAbstractInitFRNDEvent abs ev.toAbstractInitFRNDEventSpec
 
-structure AbstractInitFRNDEventSpec'' (AM) [Machine ACTX AM]
-                             (M) [Machine CTX M]
+structure AbstractInitFRNDEventSpec'' (AM) [@Machine ACTX AM]
+                             (M) [@Machine CTX M]
                              [FRefinement AM M]
   (abstract : InitNDEvent AM Unit Unit)
           extends _AbstractFREventSpec'' AM M where
@@ -230,7 +230,7 @@ structure AbstractInitFRNDEventSpec'' (AM) [Machine ACTX AM]
     → lift (unlift default am' default) = am'
 
 @[simp]
-def AbstractInitFRNDEventSpec''.toAbstractInitFRNDEventSpec [Machine ACTX AM] [Machine CTX M] [instFR: FRefinement AM M]
+def AbstractInitFRNDEventSpec''.toAbstractInitFRNDEventSpec [@Machine ACTX AM] [@Machine CTX M] [instFR: FRefinement AM M]
   (abs : InitNDEvent AM Unit Unit) (ev : AbstractInitFRNDEventSpec'' AM M abs) : AbstractInitFRNDEventSpec AM M abs :=
   {
     to_AbstractFREventSpec := ev.to_AbstractFREventSpec
@@ -246,36 +246,36 @@ def AbstractInitFRNDEventSpec''.toAbstractInitFRNDEventSpec [Machine ACTX AM] [M
   }
 
 @[simp]
-def newAbstractInitFRNDEvent'' [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAbstractInitFRNDEvent'' [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : InitNDEvent AM Unit Unit) (ev : AbstractInitFRNDEventSpec'' AM M abs) : InitRNDEvent AM M Unit Unit :=
   newAbstractInitFRNDEvent abs ev.toAbstractInitFRNDEventSpec
 
 @[simp]
-def newAbstractAnticipatedFRNDEvent [Preorder v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAbstractAnticipatedFRNDEvent [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : AnticipatedNDEvent v AM α β) (ev : AbstractFRNDEventSpec AM M abs.toOrdinaryNDEvent) : AnticipatedRNDEvent v AM M α β :=
   newAbstractAnticipatedRNDEvent abs ev.toAbstractRNDEventSpec
 
 @[simp]
-def newAbstractAnticipatedFRNDEvent' [Preorder v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAbstractAnticipatedFRNDEvent' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : AnticipatedNDEvent v AM α Unit) (ev : AbstractFRNDEventSpec' AM M abs.toOrdinaryNDEvent) : AnticipatedRNDEvent v AM M α Unit :=
   newAbstractAnticipatedFRNDEvent abs ev.toAbstractFRNDEventSpec
 
 @[simp]
-def newAbstractAnticipatedFRNDEvent'' [Preorder v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAbstractAnticipatedFRNDEvent'' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : AnticipatedNDEvent v AM Unit Unit) (ev : AbstractFRNDEventSpec'' AM M abs.toOrdinaryNDEvent) : AnticipatedRNDEvent v AM M Unit Unit :=
   newAbstractAnticipatedFRNDEvent abs ev.toAbstractFRNDEventSpec
 
 @[simp]
-def newAbstractConvergentFRNDEvent [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAbstractConvergentFRNDEvent [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : ConvergentNDEvent v AM α β) (ev : AbstractFRNDEventSpec AM M abs.toAnticipatedNDEvent.toOrdinaryNDEvent) : ConvergentRNDEvent v AM M α β :=
   newAbstractConvergentRNDEvent abs ev.toAbstractRNDEventSpec
 
 @[simp]
-def newAbstractConvergentFRNDEvent' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAbstractConvergentFRNDEvent' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : ConvergentNDEvent v AM α Unit) (ev : AbstractFRNDEventSpec' AM M abs.toAnticipatedNDEvent.toOrdinaryNDEvent) : ConvergentRNDEvent v AM M α Unit :=
   newAbstractConvergentFRNDEvent abs ev.toAbstractFRNDEventSpec
 
 @[simp]
-def newAbstractConvergentFRNDEvent'' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAbstractConvergentFRNDEvent'' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : ConvergentNDEvent v AM Unit Unit) (ev : AbstractFRNDEventSpec'' AM M abs.toAnticipatedNDEvent.toOrdinaryNDEvent) : ConvergentRNDEvent v AM M Unit Unit :=
   newAbstractConvergentFRNDEvent abs ev.toAbstractFRNDEventSpec

--- a/LeanMachines/Refinement/Functional/NonDet/Basic.lean
+++ b/LeanMachines/Refinement/Functional/NonDet/Basic.lean
@@ -7,8 +7,8 @@ import LeanMachines.Refinement.Functional.Basic
 open Refinement
 open FRefinement
 
-structure FRNDEventSpec (AM) [Machine ACTX AM]
-                         (M) [Machine CTX M]
+structure FRNDEventSpec (AM) [@Machine ACTX AM]
+                         (M) [@Machine CTX M]
                          [FRefinement AM M]
   {α β α' β'} (abstract : OrdinaryNDEvent AM α' β')
   extends NDEventSpec M α β where
@@ -30,7 +30,7 @@ structure FRNDEventSpec (AM) [Machine ACTX AM]
           (lift_out y, (lift m'))
 
 @[simp]
-def FRNDEventSpec.toRNDEventSpec [Machine ACTX AM] [Machine CTX M] [instFR: FRefinement AM M]
+def FRNDEventSpec.toRNDEventSpec [@Machine ACTX AM] [@Machine CTX M] [instFR: FRefinement AM M]
   {α β α' β'} (abs : OrdinaryNDEvent AM α' β')
   (ev : FRNDEventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : RNDEventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abs :=
   {
@@ -56,12 +56,12 @@ def FRNDEventSpec.toRNDEventSpec [Machine ACTX AM] [Machine CTX M] [instFR: FRef
   }
 
 @[simp]
-def newFRNDEvent [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newFRNDEvent [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryNDEvent AM α' β') (ev : FRNDEventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : OrdinaryRNDEvent AM M α β α' β' :=
   newRNDEvent abs ev.toRNDEventSpec
 
-structure FRNDEventSpec' (AM) [Machine ACTX AM]
-                         (M) [Machine CTX M]
+structure FRNDEventSpec' (AM) [@Machine ACTX AM]
+                         (M) [@Machine CTX M]
                          [FRefinement AM M]
   {α α'} (abstract : OrdinaryNDEvent AM α' Unit)
   extends NDEventSpec' M α where
@@ -82,7 +82,7 @@ structure FRNDEventSpec' (AM) [Machine ACTX AM]
           ((), (lift m'))
 
 @[simp]
-def FRNDEventSpec'.toFRNDEventSpec [Machine ACTX AM] [Machine CTX M] [instFR: FRefinement AM M]
+def FRNDEventSpec'.toFRNDEventSpec [@Machine ACTX AM] [@Machine CTX M] [instFR: FRefinement AM M]
   {α α'} (abs : OrdinaryNDEvent AM α' Unit)
   (ev : FRNDEventSpec' AM M (α:=α) (α':=α') abs) : FRNDEventSpec AM M (α:=α) (β:=Unit) (α':=α') (β':=Unit) abs :=
   {
@@ -97,12 +97,12 @@ def FRNDEventSpec'.toFRNDEventSpec [Machine ACTX AM] [Machine CTX M] [instFR: FR
   }
 
 @[simp]
-def newFRNDEvent' [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newFRNDEvent' [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryNDEvent AM α' Unit) (ev : FRNDEventSpec' AM M (α:=α) (α':=α') abs) : OrdinaryRNDEvent AM M α Unit α' Unit :=
   newFRNDEvent abs ev.toFRNDEventSpec
 
-structure FRNDEventSpec'' (AM) [Machine ACTX AM]
-                         (M) [Machine CTX M]
+structure FRNDEventSpec'' (AM) [@Machine ACTX AM]
+                         (M) [@Machine CTX M]
                          [FRefinement AM M]
   (abstract : OrdinaryNDEvent AM Unit Unit)
   extends NDEventSpec'' M where
@@ -119,7 +119,7 @@ structure FRNDEventSpec'' (AM) [Machine ACTX AM]
       → abstract.effect (lift m) () (strengthening m Hinv Hgrd) ((), (lift m'))
 
 @[simp]
-def FRNDEventSpec''.toFRNDEventSpec [Machine ACTX AM] [Machine CTX M] [instFR: FRefinement AM M]
+def FRNDEventSpec''.toFRNDEventSpec [@Machine ACTX AM] [@Machine CTX M] [instFR: FRefinement AM M]
   (abs : OrdinaryNDEvent AM Unit Unit)
   (ev : FRNDEventSpec'' AM M abs) : FRNDEventSpec AM M (α:=Unit) (β:=Unit) (α':=Unit) (β':=Unit) abs :=
   {
@@ -134,14 +134,14 @@ def FRNDEventSpec''.toFRNDEventSpec [Machine ACTX AM] [Machine CTX M] [instFR: F
   }
 
 @[simp]
-def newFRNDEvent'' [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newFRNDEvent'' [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryNDEvent AM Unit Unit) (ev : FRNDEventSpec'' AM M abs) : OrdinaryRNDEvent AM M Unit Unit :=
   newFRNDEvent abs ev.toFRNDEventSpec
 
 /- Initialization events -/
 
-structure InitFRNDEventSpec (AM) [Machine ACTX AM]
-                        (M) [Machine CTX M]
+structure InitFRNDEventSpec (AM) [@Machine ACTX AM]
+                        (M) [@Machine CTX M]
                         [FRefinement AM M]
   {α β α' β'} (abstract : InitNDEvent AM α' β')
   extends InitNDEventSpec M α β where
@@ -159,7 +159,7 @@ structure InitFRNDEventSpec (AM) [Machine ACTX AM]
       → abstract.init (lift_in x) (strengthening x Hgrd) (lift_out y, (lift m'))
 
 @[simp]
-def InitFRNDEventSpec.toInitRNDEventSpec [Machine ACTX AM] [Machine CTX M] [instFR: FRefinement AM M]
+def InitFRNDEventSpec.toInitRNDEventSpec [@Machine ACTX AM] [@Machine CTX M] [instFR: FRefinement AM M]
   {α β α' β'} (abs : InitNDEvent AM α' β')
   (ev : InitFRNDEventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : InitRNDEventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abs :=
   {
@@ -174,13 +174,13 @@ def InitFRNDEventSpec.toInitRNDEventSpec [Machine ACTX AM] [Machine CTX M] [inst
   }
 
 @[simp]
-def newInitFRNDEvent [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newInitFRNDEvent [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : InitNDEvent AM α' β')
   (ev : InitFRNDEventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : InitRNDEvent AM M α β α' β' :=
   newInitRNDEvent abs ev.toInitRNDEventSpec
 
-structure InitFRNDEventSpec' (AM) [Machine ACTX AM]
-                        (M) [Machine CTX M]
+structure InitFRNDEventSpec' (AM) [@Machine ACTX AM]
+                        (M) [@Machine CTX M]
                         [FRefinement AM M]
   {α α'} (abstract : InitNDEvent AM α' Unit)
   extends InitNDEventSpec' M α where
@@ -197,7 +197,7 @@ structure InitFRNDEventSpec' (AM) [Machine ACTX AM]
       → abstract.init (lift_in x) (strengthening x Hgrd) ((), (lift m'))
 
 @[simp]
-def InitFRNDEventSpec'.toInitFRNDEventSpec [Machine ACTX AM] [Machine CTX M] [instFR: FRefinement AM M]
+def InitFRNDEventSpec'.toInitFRNDEventSpec [@Machine ACTX AM] [@Machine CTX M] [instFR: FRefinement AM M]
   {α α'} (abs : InitNDEvent AM α' Unit)
   (ev : InitFRNDEventSpec' AM M (α:=α) (α':=α') abs) : InitFRNDEventSpec AM M (α:=α) (β:=Unit) (α':=α') (β':=Unit) abs :=
   {
@@ -212,13 +212,13 @@ def InitFRNDEventSpec'.toInitFRNDEventSpec [Machine ACTX AM] [Machine CTX M] [in
   }
 
 @[simp]
-def newInitFRNDEvent' [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newInitFRNDEvent' [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : InitNDEvent AM α' Unit)
   (ev : InitFRNDEventSpec' AM M (α:=α) (α':=α') abs) : InitRNDEvent AM M α Unit α' Unit :=
   newInitFRNDEvent abs ev.toInitFRNDEventSpec
 
-structure InitFRNDEventSpec'' (AM) [Machine ACTX AM]
-                        (M) [Machine CTX M]
+structure InitFRNDEventSpec'' (AM) [@Machine ACTX AM]
+                        (M) [@Machine CTX M]
                         [FRefinement AM M]
   (abstract : InitNDEvent AM Unit Unit)
   extends InitNDEventSpec'' M where
@@ -233,7 +233,7 @@ structure InitFRNDEventSpec'' (AM) [Machine ACTX AM]
       → abstract.init () (strengthening Hgrd) ((), (lift m'))
 
 @[simp]
-def InitFRNDEventSpec''.toInitFRNDEventSpec [Machine ACTX AM] [Machine CTX M] [instFR: FRefinement AM M]
+def InitFRNDEventSpec''.toInitFRNDEventSpec [@Machine ACTX AM] [@Machine CTX M] [instFR: FRefinement AM M]
   (abs : InitNDEvent AM Unit Unit)
   (ev : InitFRNDEventSpec'' AM M abs) : InitFRNDEventSpec AM M (α:=Unit) (β:=Unit) (α':=Unit) (β':=Unit) abs :=
   {
@@ -248,7 +248,7 @@ def InitFRNDEventSpec''.toInitFRNDEventSpec [Machine ACTX AM] [Machine CTX M] [i
   }
 
 @[simp]
-def newInitFRNDEvent'' [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newInitFRNDEvent'' [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : InitNDEvent AM Unit Unit)
   (ev : InitFRNDEventSpec'' AM M abs) : InitRNDEvent AM M Unit Unit :=
   newInitFRNDEvent abs ev.toInitFRNDEventSpec

--- a/LeanMachines/Refinement/Functional/NonDet/Concrete.lean
+++ b/LeanMachines/Refinement/Functional/NonDet/Concrete.lean
@@ -10,7 +10,7 @@ import LeanMachines.Refinement.Relational.NonDet.Concrete
 open Refinement
 open FRefinement
 
-structure ConcreteFRNDEventSpec (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR: FRefinement AM M] (α) (β)
+structure ConcreteFRNDEventSpec (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instR: FRefinement AM M] (α) (β)
   extends NDEventSpec M α β where
 
   simulation (m : M) (x : α):
@@ -20,7 +20,7 @@ structure ConcreteFRNDEventSpec (AM) [Machine ACTX AM] (M) [Machine CTX M] [inst
                    → (lift m') = (lift (AM:=AM) m)
 
 @[simp]
-def ConcreteFRNDEventSpec.toConcreteRNDEventSpec [Machine ACTX AM] [Machine CTX M] [instFR: FRefinement AM M]
+def ConcreteFRNDEventSpec.toConcreteRNDEventSpec [@Machine ACTX AM] [@Machine CTX M] [instFR: FRefinement AM M]
   (ev : ConcreteFRNDEventSpec AM M α β) : ConcreteRNDEventSpec AM M α β :=
   {
     toNDEventSpec := ev.toNDEventSpec
@@ -33,11 +33,11 @@ def ConcreteFRNDEventSpec.toConcreteRNDEventSpec [Machine ACTX AM] [Machine CTX 
   }
 
 @[simp]
-def newConcreteFRNDEvent [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newConcreteFRNDEvent [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (ev : ConcreteFRNDEventSpec AM M α β) : OrdinaryRNDEvent AM M α β :=
   newConcreteRNDEvent ev.toConcreteRNDEventSpec
 
-structure ConcreteFRNDEventSpec' (AM) [Machine ACTX AM] (M) [Machine CTX M] [FRefinement AM M] (α)
+structure ConcreteFRNDEventSpec' (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [FRefinement AM M] (α)
   extends NDEventSpec' M α where
 
   simulation (m : M) (x : α):
@@ -47,7 +47,7 @@ structure ConcreteFRNDEventSpec' (AM) [Machine ACTX AM] (M) [Machine CTX M] [FRe
             → (lift m') = (lift (AM:=AM) m)
 
 @[simp]
-def ConcreteFRNDEventSpec'.toConcreteFRNDEventSpec [Machine ACTX AM] [Machine CTX M] [instFR: FRefinement AM M]
+def ConcreteFRNDEventSpec'.toConcreteFRNDEventSpec [@Machine ACTX AM] [@Machine CTX M] [instFR: FRefinement AM M]
   (ev : ConcreteFRNDEventSpec' AM M α) : ConcreteFRNDEventSpec AM M α Unit :=
   {
     toNDEventSpec := ev.toNDEventSpec
@@ -55,11 +55,11 @@ def ConcreteFRNDEventSpec'.toConcreteFRNDEventSpec [Machine ACTX AM] [Machine CT
   }
 
 @[simp]
-def newConcreteFRNDEvent' [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newConcreteFRNDEvent' [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (ev : ConcreteFRNDEventSpec' AM M α) : OrdinaryRNDEvent AM M α Unit :=
   newConcreteFRNDEvent ev.toConcreteFRNDEventSpec
 
-structure ConcreteFRNDEventSpec'' (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR: FRefinement AM M]
+structure ConcreteFRNDEventSpec'' (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instR: FRefinement AM M]
   extends NDEventSpec'' M where
 
   simulation (m : M):
@@ -69,7 +69,7 @@ structure ConcreteFRNDEventSpec'' (AM) [Machine ACTX AM] (M) [Machine CTX M] [in
             → (lift m') = (lift (AM:=AM) m)
 
 @[simp]
-def ConcreteFRNDEventSpec''.toConcreteFRNDEventSpec [Machine ACTX AM] [Machine CTX M] [instFR: FRefinement AM M]
+def ConcreteFRNDEventSpec''.toConcreteFRNDEventSpec [@Machine ACTX AM] [@Machine CTX M] [instFR: FRefinement AM M]
   (ev : ConcreteFRNDEventSpec'' AM M) : ConcreteFRNDEventSpec AM M Unit Unit :=
   {
     toNDEventSpec := ev.toNDEventSpec
@@ -77,13 +77,13 @@ def ConcreteFRNDEventSpec''.toConcreteFRNDEventSpec [Machine ACTX AM] [Machine C
   }
 
 @[simp]
-def newConcreteFRNDEvent'' [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newConcreteFRNDEvent'' [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (ev : ConcreteFRNDEventSpec'' AM M) : OrdinaryRNDEvent AM M Unit Unit :=
   newConcreteFRNDEvent ev.toConcreteFRNDEventSpec
 
 /- Anticipated concrete events -/
 
-structure ConcreteAnticipatedFRNDEventSpec (v) [Preorder v] [WellFoundedLT v] (AM) [Machine ACTX AM] (M) [instM:Machine CTX M] [instR: FRefinement AM M] (α) (β)
+structure ConcreteAnticipatedFRNDEventSpec (v) [Preorder v] [WellFoundedLT v] (AM) [@Machine ACTX AM] (M) [instM:@Machine CTX M] [instR: FRefinement AM M] (α) (β)
   extends _Variant v (instM:=instM), ConcreteFRNDEventSpec AM M α β where
 
   nonIncreasing (m : M) (x : α):
@@ -93,7 +93,7 @@ structure ConcreteAnticipatedFRNDEventSpec (v) [Preorder v] [WellFoundedLT v] (A
                  → variant m' ≤ variant m
 
 @[simp]
-def ConcreteAnticipatedFRNDEventSpec.toConcreteAnticipatedRNDEventSpec [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [instFR: FRefinement AM M]
+def ConcreteAnticipatedFRNDEventSpec.toConcreteAnticipatedRNDEventSpec [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [instFR: FRefinement AM M]
   (ev : ConcreteAnticipatedFRNDEventSpec v AM M α β) : ConcreteAnticipatedRNDEventSpec v AM M α β :=
   {
     toNDEventSpec := ev.toNDEventSpec
@@ -110,11 +110,11 @@ def ConcreteAnticipatedFRNDEventSpec.toConcreteAnticipatedRNDEventSpec [Preorder
   }
 
 @[simp]
-def newConcreteAnticipatedFRNDEvent [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newConcreteAnticipatedFRNDEvent [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (ev : ConcreteAnticipatedFRNDEventSpec v AM M α β) : AnticipatedRNDEvent v AM M α β :=
   newConcreteAnticipatedRNDEvent ev.toConcreteAnticipatedRNDEventSpec
 
-structure ConcreteAnticipatedFRNDEventSpec' (v) [Preorder v] [WellFoundedLT v] (AM) [Machine ACTX AM] (M) [Machine CTX M] [FRefinement AM M] (α)
+structure ConcreteAnticipatedFRNDEventSpec' (v) [Preorder v] [WellFoundedLT v] (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [FRefinement AM M] (α)
   extends _Variant v (M:=M), ConcreteFRNDEventSpec' AM M α where
 
   nonIncreasing (m : M) (x : α):
@@ -124,7 +124,7 @@ structure ConcreteAnticipatedFRNDEventSpec' (v) [Preorder v] [WellFoundedLT v] (
             → variant m' ≤ variant m
 
 @[simp]
-def ConcreteAnticipatedFRNDEventSpec'.toConcreteAnticipatedFRNDEventSpec [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [instFR: FRefinement AM M]
+def ConcreteAnticipatedFRNDEventSpec'.toConcreteAnticipatedFRNDEventSpec [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [instFR: FRefinement AM M]
   (ev : ConcreteAnticipatedFRNDEventSpec' v AM M α) : ConcreteAnticipatedFRNDEventSpec v AM M α Unit :=
   {
     toNDEventSpec := ev.toNDEventSpec
@@ -134,11 +134,11 @@ def ConcreteAnticipatedFRNDEventSpec'.toConcreteAnticipatedFRNDEventSpec [Preord
   }
 
 @[simp]
-def newConcreteAnticipatedFRNDEvent' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newConcreteAnticipatedFRNDEvent' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (ev : ConcreteAnticipatedFRNDEventSpec' v AM M α) : AnticipatedRNDEvent v AM M α Unit :=
   newConcreteAnticipatedFRNDEvent ev.toConcreteAnticipatedFRNDEventSpec
 
-structure ConcreteAnticipatedFRNDEventSpec'' (v) [Preorder v] [WellFoundedLT v] (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR: FRefinement AM M]
+structure ConcreteAnticipatedFRNDEventSpec'' (v) [Preorder v] [WellFoundedLT v] (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instR: FRefinement AM M]
   extends _Variant v (M:=M), ConcreteFRNDEventSpec'' AM M where
 
   nonIncreasing (m : M):
@@ -148,7 +148,7 @@ structure ConcreteAnticipatedFRNDEventSpec'' (v) [Preorder v] [WellFoundedLT v] 
             → variant m' ≤ variant m
 
 @[simp]
-def ConcreteAnticipatedFRNDEventSpec''.toConcreteAnticipatedFRNDEventSpec [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [instFR: FRefinement AM M]
+def ConcreteAnticipatedFRNDEventSpec''.toConcreteAnticipatedFRNDEventSpec [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [instFR: FRefinement AM M]
   (ev : ConcreteAnticipatedFRNDEventSpec'' v AM M) : ConcreteAnticipatedFRNDEventSpec v AM M Unit Unit :=
   {
     toNDEventSpec := ev.toNDEventSpec
@@ -158,13 +158,13 @@ def ConcreteAnticipatedFRNDEventSpec''.toConcreteAnticipatedFRNDEventSpec [Preor
   }
 
 @[simp]
-def newConcreteAnticipatedFRNDEvent'' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newConcreteAnticipatedFRNDEvent'' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (ev : ConcreteAnticipatedFRNDEventSpec'' v AM M) : AnticipatedRNDEvent v AM M Unit Unit :=
   newConcreteAnticipatedFRNDEvent ev.toConcreteAnticipatedFRNDEventSpec
 
 /- Convergent concrete events -/
 
-structure ConcreteConvergentFRNDEventSpec (v) [Preorder v] [WellFoundedLT v] (AM) [Machine ACTX AM] (M) [instM:Machine CTX M] [instR: FRefinement AM M] (α) (β)
+structure ConcreteConvergentFRNDEventSpec (v) [Preorder v] [WellFoundedLT v] (AM) [@Machine ACTX AM] (M) [instM:@Machine CTX M] [instR: FRefinement AM M] (α) (β)
   extends _Variant v (instM:=instM), ConcreteFRNDEventSpec AM M α β where
 
   convergence (m : M) (x : α):
@@ -174,7 +174,7 @@ structure ConcreteConvergentFRNDEventSpec (v) [Preorder v] [WellFoundedLT v] (AM
                  → variant m' < variant m
 
 @[simp]
-def ConcreteConvergentFRNDEventSpec.toConcreteConvergentRNDEventSpec [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [instFR: FRefinement AM M]
+def ConcreteConvergentFRNDEventSpec.toConcreteConvergentRNDEventSpec [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [instFR: FRefinement AM M]
   (ev : ConcreteConvergentFRNDEventSpec v AM M α β) : ConcreteConvergentRNDEventSpec v AM M α β :=
   {
     toNDEventSpec := ev.toNDEventSpec
@@ -191,11 +191,11 @@ def ConcreteConvergentFRNDEventSpec.toConcreteConvergentRNDEventSpec [Preorder v
   }
 
 @[simp]
-def newConcreteConvergentFRNDEvent [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newConcreteConvergentFRNDEvent [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (ev : ConcreteConvergentFRNDEventSpec v AM M α β) : ConvergentRNDEvent v AM M α β :=
   newConcreteConvergentRNDEvent ev.toConcreteConvergentRNDEventSpec
 
-structure ConcreteConvergentFRNDEventSpec' (v) [Preorder v] [WellFoundedLT v] (AM) [Machine ACTX AM] (M) [Machine CTX M] [FRefinement AM M] (α)
+structure ConcreteConvergentFRNDEventSpec' (v) [Preorder v] [WellFoundedLT v] (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [FRefinement AM M] (α)
   extends _Variant v (M:=M), ConcreteFRNDEventSpec' AM M α where
 
   convergence (m : M) (x : α):
@@ -205,7 +205,7 @@ structure ConcreteConvergentFRNDEventSpec' (v) [Preorder v] [WellFoundedLT v] (A
             → variant m' < variant m
 
 @[simp]
-def ConcreteConvergentFRNDEventSpec'.toConcreteConvergentFRNDEventSpec [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [instFR: FRefinement AM M]
+def ConcreteConvergentFRNDEventSpec'.toConcreteConvergentFRNDEventSpec [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [instFR: FRefinement AM M]
   (ev : ConcreteConvergentFRNDEventSpec' v AM M α) : ConcreteConvergentFRNDEventSpec v AM M α Unit :=
   {
     toNDEventSpec := ev.toNDEventSpec
@@ -215,11 +215,11 @@ def ConcreteConvergentFRNDEventSpec'.toConcreteConvergentFRNDEventSpec [Preorder
   }
 
 @[simp]
-def newConcreteConvergentFRNDEvent' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newConcreteConvergentFRNDEvent' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (ev : ConcreteConvergentFRNDEventSpec' v AM M α) : ConvergentRNDEvent v AM M α Unit :=
   newConcreteConvergentFRNDEvent ev.toConcreteConvergentFRNDEventSpec
 
-structure ConcreteConvergentFRNDEventSpec'' (v) [Preorder v] [WellFoundedLT v] (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR: FRefinement AM M]
+structure ConcreteConvergentFRNDEventSpec'' (v) [Preorder v] [WellFoundedLT v] (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instR: FRefinement AM M]
   extends _Variant v (M:=M), ConcreteFRNDEventSpec'' AM M where
 
   convergence (m : M):
@@ -229,7 +229,7 @@ structure ConcreteConvergentFRNDEventSpec'' (v) [Preorder v] [WellFoundedLT v] (
             → variant m' < variant m
 
 @[simp]
-def ConcreteConvergentFRNDEventSpec''.toConcreteConvergentFRNDEventSpec [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [instFR: FRefinement AM M]
+def ConcreteConvergentFRNDEventSpec''.toConcreteConvergentFRNDEventSpec [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [instFR: FRefinement AM M]
   (ev : ConcreteConvergentFRNDEventSpec'' v AM M) : ConcreteConvergentFRNDEventSpec v AM M Unit Unit :=
   {
     toNDEventSpec := ev.toNDEventSpec
@@ -239,6 +239,6 @@ def ConcreteConvergentFRNDEventSpec''.toConcreteConvergentFRNDEventSpec [Preorde
   }
 
 @[simp]
-def newConcreteConvergentFRNDEvent'' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newConcreteConvergentFRNDEvent'' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (ev : ConcreteConvergentFRNDEventSpec'' v AM M) : ConvergentRNDEvent v AM M Unit Unit :=
   newConcreteConvergentFRNDEvent ev.toConcreteConvergentFRNDEventSpec

--- a/LeanMachines/Refinement/Functional/NonDet/Convergent.lean
+++ b/LeanMachines/Refinement/Functional/NonDet/Convergent.lean
@@ -6,49 +6,49 @@ open Refinement
 open FRefinement
 
 @[simp]
-def newAnticipatedFRNDEventfromOrdinary [Preorder v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAnticipatedFRNDEventfromOrdinary [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryNDEvent AM α' β')
   (ev : AnticipatedRNDEventSpec v AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : AnticipatedRNDEvent v AM M α β α' β' :=
   newAnticipatedRNDEventfromOrdinary abs ev
 
 @[simp]
-def newAnticipatedFRNDEventfromOrdinary' [Preorder v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAnticipatedFRNDEventfromOrdinary' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryNDEvent AM α' Unit)
   (ev : AnticipatedRNDEventSpec' v AM M (α:=α) (α':=α') abs) : AnticipatedRNDEvent v AM M α Unit α' Unit :=
   newAnticipatedRNDEventfromOrdinary abs ev.toAnticipatedRNDEventSpec
 
 @[simp]
-def newAnticipatedFRNDEventfromOrdinary'' [Preorder v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAnticipatedFRNDEventfromOrdinary'' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryNDEvent AM Unit Unit)
   (ev : AnticipatedRNDEventSpec'' v AM M abs) : AnticipatedRNDEvent v AM M Unit Unit :=
   newAnticipatedRNDEventfromOrdinary abs ev.toAnticipatedRNDEventSpec
 
 @[simp]
-def newAnticipatedFRNDEventfromAnticipated [Preorder v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAnticipatedFRNDEventfromAnticipated [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : AnticipatedNDEvent v AM α' β') (ev : AnticipatedRNDEventSpec v AM M (α:=α) (β:=β) (α':=α') (β':=β') abs.toOrdinaryNDEvent) : AnticipatedRNDEvent v AM M α β α' β' :=
   newAnticipatedRNDEventfromAnticipated abs ev
 
 @[simp]
-def newAnticipatedFRNDEventfromAnticipated' [Preorder v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAnticipatedFRNDEventfromAnticipated' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : AnticipatedNDEvent v AM α' Unit) (ev : AnticipatedRNDEventSpec' v AM M (α:=α) (α':=α') abs.toOrdinaryNDEvent) : AnticipatedRNDEvent v AM M α Unit α' Unit :=
   newAnticipatedRNDEventfromAnticipated abs ev.toAnticipatedRNDEventSpec
 
 @[simp]
-def newAnticipatedFRNDEventfromAnticipated'' [Preorder v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAnticipatedFRNDEventfromAnticipated'' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : AnticipatedNDEvent v AM Unit Unit) (ev : AnticipatedRNDEventSpec'' v AM M abs.toOrdinaryNDEvent) : AnticipatedRNDEvent v AM M Unit Unit :=
   newAnticipatedRNDEventfromAnticipated abs ev.toAnticipatedRNDEventSpec
 
 @[simp]
-def newConvergentFRNDEvent [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newConvergentFRNDEvent [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryNDEvent AM α' β') (ev : ConvergentRNDEventSpec v AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : ConvergentRNDEvent v AM M α β α' β' :=
   newConvergentRNDEvent abs ev
 
 @[simp]
-def newConvergentFRNDEvent' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newConvergentFRNDEvent' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryNDEvent AM α' Unit) (ev : ConvergentRNDEventSpec' v AM M (α:=α) (α':=α') abs) : ConvergentRNDEvent v AM M α Unit α' Unit :=
   newConvergentRNDEvent abs ev.toConvergentRNDEventSpec
 
 @[simp]
-def newConvergentFRNDEvent'' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newConvergentFRNDEvent'' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryNDEvent AM Unit Unit) (ev : ConvergentRNDEventSpec'' v AM M abs) : ConvergentRNDEvent v AM M Unit Unit :=
   newConvergentRNDEvent abs ev.toConvergentRNDEventSpec

--- a/LeanMachines/Refinement/Functional/NonDet/Det/Basic.lean
+++ b/LeanMachines/Refinement/Functional/NonDet/Det/Basic.lean
@@ -6,7 +6,7 @@ import LeanMachines.Refinement.Relational.NonDet.Det.Basic
 open Refinement
 open FRefinement
 
-structure FRDetEventSpec (AM) [Machine ACTX AM] (M) [Machine CTX M] [FRefinement AM M]
+structure FRDetEventSpec (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [FRefinement AM M]
   {α β α' β'} (abstract : OrdinaryNDEvent AM α' β')
   extends EventSpec M α β where
 
@@ -27,7 +27,7 @@ structure FRDetEventSpec (AM) [Machine ACTX AM] (M) [Machine CTX M] [FRefinement
         (lift_out y, lift m')
 
 @[simp]
-def FRDetEventSpec.toRDetEventSpec [Machine ACTX AM] [Machine CTX M] [instFR: FRefinement AM M]
+def FRDetEventSpec.toRDetEventSpec [@Machine ACTX AM] [@Machine CTX M] [instFR: FRefinement AM M]
   (abstract : OrdinaryNDEvent AM α' β') (ev : FRDetEventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abstract) : RDetEventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abstract :=
   {
     toEventSpec := ev.toEventSpec
@@ -51,12 +51,12 @@ def FRDetEventSpec.toRDetEventSpec [Machine ACTX AM] [Machine CTX M] [instFR: FR
   }
 
 @[simp]
-def newFRDetEvent [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newFRDetEvent [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryNDEvent AM α' β')
   (ev : FRDetEventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : OrdinaryRDetEvent AM M α β α' β':=
   newRDetEvent abs ev.toRDetEventSpec
 
-structure FRDetEventSpec' (AM) [Machine ACTX AM] (M) [Machine CTX M] [FRefinement AM M]
+structure FRDetEventSpec' (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [FRefinement AM M]
   {α α'} (abstract : OrdinaryNDEvent AM α' Unit)
   extends EventSpec' M α where
 
@@ -76,7 +76,7 @@ structure FRDetEventSpec' (AM) [Machine ACTX AM] (M) [Machine CTX M] [FRefinemen
         ((), lift m')
 
 @[simp]
-def FRDetEventSpec'.toFRDetEventSpec [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def FRDetEventSpec'.toFRDetEventSpec [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abstract : OrdinaryNDEvent AM α' Unit) (ev : FRDetEventSpec' AM M (α:=α) (α':=α') abstract) : FRDetEventSpec AM M (α:=α) (β:=Unit) (α':=α') (β':=Unit) abstract :=
   {
     toEventSpec := ev.toEventSpec
@@ -87,12 +87,12 @@ def FRDetEventSpec'.toFRDetEventSpec [Machine ACTX AM] [Machine CTX M] [FRefinem
   }
 
 @[simp]
-def newFRDetEvent' [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newFRDetEvent' [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryNDEvent AM α' Unit)
   (ev : FRDetEventSpec' AM M (α:=α) (α':=α') abs) : OrdinaryRDetEvent AM M α Unit α' Unit:=
   newFRDetEvent abs ev.toFRDetEventSpec
 
-structure FRDetEventSpec'' (AM) [Machine ACTX AM] (M) [Machine CTX M] [FRefinement AM M]
+structure FRDetEventSpec'' (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [FRefinement AM M]
   (abstract : OrdinaryNDEvent AM Unit Unit)
   extends EventSpec'' M where
 
@@ -108,7 +108,7 @@ structure FRDetEventSpec'' (AM) [Machine ACTX AM] (M) [Machine CTX M] [FRefineme
       abstract.effect (lift m) () (strengthening m Hinv Hgrd) ((), lift m')
 
 @[simp]
-def FRDetEventSpec''.toFRDetEventSpec [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def FRDetEventSpec''.toFRDetEventSpec [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abstract : OrdinaryNDEvent AM Unit Unit) (ev : FRDetEventSpec'' AM M abstract) : FRDetEventSpec AM M (α:=Unit) (β:=Unit) (α':=Unit) (β':=Unit) abstract :=
   {
     toEventSpec := ev.toEventSpec
@@ -119,7 +119,7 @@ def FRDetEventSpec''.toFRDetEventSpec [Machine ACTX AM] [Machine CTX M] [FRefine
   }
 
 @[simp]
-def newFRDetEvent'' [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newFRDetEvent'' [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryNDEvent AM Unit Unit)
   (ev : FRDetEventSpec'' AM M abs) : OrdinaryRDetEvent AM M Unit Unit:=
   newFRDetEvent abs ev.toFRDetEventSpec
@@ -127,7 +127,7 @@ def newFRDetEvent'' [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
 
 /- Initialization events -/
 
-structure InitFRDetEventSpec (AM) [Machine ACTX AM] (M) [Machine CTX M] [FRefinement AM M]
+structure InitFRDetEventSpec (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [FRefinement AM M]
   {α β α' β'} (abstract : InitNDEvent AM α' β')
   extends InitEventSpec M α β where
 
@@ -144,7 +144,7 @@ structure InitFRDetEventSpec (AM) [Machine ACTX AM] (M) [Machine CTX M] [FRefine
       abstract.init (lift_in x) (strengthening x Hgrd) (lift_out y, lift m')
 
 @[simp]
-def InitFRDetEventSpec.toInitRDetEventSpec  [Machine ACTX AM] [Machine CTX M] [instFR:FRefinement AM M]
+def InitFRDetEventSpec.toInitRDetEventSpec  [@Machine ACTX AM] [@Machine CTX M] [instFR:FRefinement AM M]
   (abstract : InitNDEvent AM α' β')
   (ev : InitFRDetEventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abstract) : InitRDetEventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abstract :=
   {
@@ -161,12 +161,12 @@ def InitFRDetEventSpec.toInitRDetEventSpec  [Machine ACTX AM] [Machine CTX M] [i
   }
 
 @[simp]
-def newInitFRDetEvent [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newInitFRDetEvent [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : InitNDEvent AM α' β')
   (ev : InitFRDetEventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : InitRDetEvent AM M α β α' β' :=
   newInitRDetEvent abs ev.toInitRDetEventSpec
 
-structure InitFRDetEventSpec' (AM) [Machine ACTX AM] (M) [Machine CTX M] [FRefinement AM M]
+structure InitFRDetEventSpec' (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [FRefinement AM M]
   {α α'} (abstract : InitNDEvent AM α' Unit)
   extends InitEventSpec' M α where
 
@@ -182,7 +182,7 @@ structure InitFRDetEventSpec' (AM) [Machine ACTX AM] (M) [Machine CTX M] [FRefin
       abstract.init (lift_in x) (strengthening x Hgrd) ((), lift m')
 
 @[simp]
-def InitFRDetEventSpec'.toInitFRDetEventSpec  [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def InitFRDetEventSpec'.toInitFRDetEventSpec  [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abstract : InitNDEvent AM α' Unit)
   (ev : InitFRDetEventSpec' AM M (α:=α) (α':=α') abstract) : InitFRDetEventSpec AM M (α:=α) (β:=Unit) (α':=α') (β':=Unit) abstract :=
   {
@@ -194,12 +194,12 @@ def InitFRDetEventSpec'.toInitFRDetEventSpec  [Machine ACTX AM] [Machine CTX M] 
   }
 
 @[simp]
-def newInitFRDetEvent' [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newInitFRDetEvent' [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : InitNDEvent AM α' Unit)
   (ev : InitFRDetEventSpec' AM M (α:=α) (α':=α') abs) : InitRDetEvent AM M α Unit α' Unit :=
   newInitFRDetEvent abs ev.toInitFRDetEventSpec
 
-structure InitFRDetEventSpec'' (AM) [Machine ACTX AM] (M) [Machine CTX M] [FRefinement AM M]
+structure InitFRDetEventSpec'' (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [FRefinement AM M]
   (abstract : InitNDEvent AM Unit Unit)
   extends InitEventSpec'' M where
 
@@ -213,7 +213,7 @@ structure InitFRDetEventSpec'' (AM) [Machine ACTX AM] (M) [Machine CTX M] [FRefi
       abstract.init () (strengthening Hgrd) ((), lift m')
 
 @[simp]
-def InitFRDetEventSpec''.toInitFRDetEventSpec  [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def InitFRDetEventSpec''.toInitFRDetEventSpec  [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abstract : InitNDEvent AM Unit Unit)
   (ev : InitFRDetEventSpec'' AM M abstract) : InitFRDetEventSpec AM M (α:=Unit) (β:=Unit) (α':=Unit) (β':=Unit) abstract :=
   {
@@ -225,7 +225,7 @@ def InitFRDetEventSpec''.toInitFRDetEventSpec  [Machine ACTX AM] [Machine CTX M]
   }
 
 @[simp]
-def newInitFRDetEvent'' [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newInitFRDetEvent'' [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : InitNDEvent AM Unit Unit)
   (ev : InitFRDetEventSpec'' AM M abs) : InitRDetEvent AM M Unit Unit :=
   newInitFRDetEvent abs ev.toInitFRDetEventSpec

--- a/LeanMachines/Refinement/Functional/NonDet/Det/Convergent.lean
+++ b/LeanMachines/Refinement/Functional/NonDet/Det/Convergent.lean
@@ -10,46 +10,46 @@ open Refinement
 open FRefinement
 
 @[simp]
-def newAnticipatedFRDetEventfromOrdinary [Preorder v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAnticipatedFRDetEventfromOrdinary [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryNDEvent AM α' β') (ev : AnticipatedRDetEventSpec v AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : AnticipatedRDetEvent v AM M α β α' β' :=
   newAnticipatedRDetEventfromOrdinary abs ev
 
 @[simp]
-def newAnticipatedFRDetEventfromOrdinary' [Preorder v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAnticipatedFRDetEventfromOrdinary' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryNDEvent AM α' Unit) (ev : AnticipatedRDetEventSpec' v AM M (α:=α) (α':=α') abs) : AnticipatedRDetEvent v AM M α Unit α' Unit :=
   newAnticipatedFRDetEventfromOrdinary abs ev.toAnticipatedRDetEventSpec
 
 @[simp]
-def newAnticipatedFRDetEventfromOrdinary'' [Preorder v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAnticipatedFRDetEventfromOrdinary'' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryNDEvent AM Unit Unit) (ev : AnticipatedRDetEventSpec'' v AM M abs) : AnticipatedRDetEvent v AM M Unit Unit :=
   newAnticipatedFRDetEventfromOrdinary abs ev.toAnticipatedRDetEventSpec
 
 @[simp]
-def newAnticipatedFRDetEventfromAnticipated [Preorder v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAnticipatedFRDetEventfromAnticipated [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : AnticipatedNDEvent v AM α' β') (ev : AnticipatedRDetEventSpec v AM M (α:=α) (β:=β) (α':=α') (β':=β') abs.toOrdinaryNDEvent) : AnticipatedRDetEvent v AM M α β α' β' :=
   newAnticipatedRDetEventfromAnticipated abs ev
 
 @[simp]
-def newAnticipatedFRDetEventfromAnticipated' [Preorder v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAnticipatedFRDetEventfromAnticipated' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : AnticipatedNDEvent v AM α' Unit) (ev : AnticipatedRDetEventSpec' v AM M (α:=α) (α':=α') abs.toOrdinaryNDEvent) : AnticipatedRDetEvent v AM M α Unit α' Unit :=
   newAnticipatedFRDetEventfromAnticipated abs ev.toAnticipatedRDetEventSpec
 
 @[simp]
-def newAnticipatedFRDetEventfromAnticipated'' [Preorder v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newAnticipatedFRDetEventfromAnticipated'' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : AnticipatedNDEvent v AM Unit Unit) (ev : AnticipatedRDetEventSpec'' v AM M abs.toOrdinaryNDEvent) : AnticipatedRDetEvent v AM M Unit Unit :=
   newAnticipatedFRDetEventfromAnticipated abs ev.toAnticipatedRDetEventSpec
 
 @[simp]
-def newConvergentFRDetEvent [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newConvergentFRDetEvent [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryNDEvent AM α' β') (ev : ConvergentRDetEventSpec v AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : ConvergentRDetEvent v AM M α β α' β' :=
   newConvergentRDetEvent abs ev
 
 @[simp]
-def newConvergentFRDetEvent' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newConvergentFRDetEvent' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryNDEvent AM α' Unit) (ev : ConvergentRDetEventSpec' v AM M (α:=α) (α':=α') abs) : ConvergentRDetEvent v AM M α Unit α' Unit :=
   newConvergentFRDetEvent abs ev.toConvergentRDetEventSpec
 
 @[simp]
-def newConvergentFRDetEvent'' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [FRefinement AM M]
+def newConvergentFRDetEvent'' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [FRefinement AM M]
   (abs : OrdinaryNDEvent AM Unit Unit) (ev : ConvergentRDetEventSpec'' v AM M abs) : ConvergentRDetEvent v AM M Unit Unit :=
   newConvergentFRDetEvent abs ev.toConvergentRDetEventSpec

--- a/LeanMachines/Refinement/Relational/Abstract.lean
+++ b/LeanMachines/Refinement/Relational/Abstract.lean
@@ -58,8 +58,8 @@ open Refinement
 -/
 
 /-- Reuse of abstract events: the `lift ` part of machine-level requirements. -/
-structure __AbstractREventSpec (AM) [Machine ACTX AM]
-                               (M) [Machine CTX M]
+structure __AbstractREventSpec (AM) [@Machine ACTX AM]
+                               (M) [@Machine CTX M]
                                [Refinement AM M] where
   /-- The construction of an abstract state from the concrete state `m`. -/
   lift (m: M) : AM
@@ -76,8 +76,8 @@ structure __AbstractREventSpec (AM) [Machine ACTX AM]
 
 
 /-- Reuse of abstract events: the `unlift ` part of machine-level requirements. -/
-structure _AbstractREventSpec (AM) [Machine ACTX AM]
-                              (M) [Machine CTX M]
+structure _AbstractREventSpec (AM) [@Machine ACTX AM]
+                              (M) [@Machine CTX M]
                               [Refinement AM M] (α)
 
   extends __AbstractREventSpec AM M  where
@@ -89,8 +89,8 @@ structure _AbstractREventSpec (AM) [Machine ACTX AM]
 /-- The specification of the reuse of an `abstract` event, with the
 `lift` and `unlift` operations, the associated proof obligations,
  and the further two event-level proof obligations. -/
-structure AbstractREventSpec (AM) [Machine ACTX AM]
-                             (M) [Machine CTX M]
+structure AbstractREventSpec (AM) [@Machine ACTX AM]
+                             (M) [@Machine CTX M]
                             [Refinement AM M]
   {α β} (abstract : OrdinaryEvent AM α β)
           extends _AbstractREventSpec AM M α where
@@ -114,7 +114,7 @@ structure AbstractREventSpec (AM) [Machine ACTX AM]
 Parameter `abs` is the event to reuse  (event of abstract machine)
 Parameter `ev` is the reuse specification (cf. `AbstractREventSpec`). -/
 @[simp]
-def newAbstractREvent [Machine ACTX AM] [Machine CTX M] [instR:Refinement AM M]
+def newAbstractREvent [@Machine ACTX AM] [@Machine CTX M] [instR:Refinement AM M]
   (abs : OrdinaryEvent AM α β) (ev : AbstractREventSpec AM M abs) : OrdinaryREvent AM M α β :=
   { guard := fun (m : M) (x : α) => abs.guard (ev.lift m) x
     action := fun (m : M) (x : α) grd =>
@@ -157,12 +157,12 @@ def newAbstractREvent [Machine ACTX AM] [Machine CTX M] [instR:Refinement AM M]
 
 /-- Variant of `newAbstractREvent` with implicit `Unit` output type -/
 @[simp]
-def newAbstractREvent' [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newAbstractREvent' [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryEvent AM α Unit) (ev : AbstractREventSpec AM M abs) : OrdinaryREvent AM M α Unit :=
   newAbstractREvent abs ev
 
-structure _AbstractREventSpec'' (AM) [Machine ACTX AM]
-                                (M) [Machine CTX M]
+structure _AbstractREventSpec'' (AM) [@Machine ACTX AM]
+                                (M) [@Machine CTX M]
                                 [Refinement AM M]
 
   extends __AbstractREventSpec AM M  where
@@ -170,8 +170,8 @@ structure _AbstractREventSpec'' (AM) [Machine ACTX AM]
   unlift (am am' : AM) (m : M): M
 
 /-- Variant of `AbstractREventSpec` with implicit `Unit` input and output types -/
-structure AbstractREventSpec'' (AM) [Machine ACTX AM]
-                               (M) [Machine CTX M]
+structure AbstractREventSpec'' (AM) [@Machine ACTX AM]
+                               (M) [@Machine CTX M]
                                [Refinement AM M]
   (abstract : OrdinaryEvent AM Unit Unit)
           extends _AbstractREventSpec'' AM M where
@@ -190,7 +190,7 @@ structure AbstractREventSpec'' (AM) [Machine ACTX AM]
       → Machine.invariant (unlift (lift m) am' m)
 
 @[simp]
-def AbstractREventSpec''.toAbstractREventSpec [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def AbstractREventSpec''.toAbstractREventSpec [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
     (abs : OrdinaryEvent AM Unit Unit) (ev : AbstractREventSpec'' AM M abs) : AbstractREventSpec AM M abs :=
   {
     to__AbstractREventSpec := ev.to__AbstractREventSpec
@@ -202,7 +202,7 @@ def AbstractREventSpec''.toAbstractREventSpec [Machine ACTX AM] [Machine CTX M] 
 
 /-- Variant of `newAbstractREvent` with implicit `Unit` input and output types -/
 @[simp]
-def newAbstractREvent'' [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newAbstractREvent'' [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryEvent AM Unit Unit) (ev : AbstractREventSpec'' AM M abs) : OrdinaryREvent AM M Unit Unit :=
   newAbstractREvent abs ev.toAbstractREventSpec
 
@@ -213,8 +213,8 @@ def newAbstractREvent'' [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
 /-- The specification of the reuse of an `abstract` initialization event,
 with the `lift` and `unlift` operations, the associated proof obligations,
  and the further two event-level proof obligations. -/
-structure AbstractInitREventSpec (AM) [Machine ACTX AM]
-                                 (M) [Machine CTX M]
+structure AbstractInitREventSpec (AM) [@Machine ACTX AM]
+                                 (M) [@Machine CTX M]
                                  [Refinement AM M]
   {α β} (abstract : InitEvent AM α β)
           extends _AbstractREventSpec AM M α where
@@ -233,7 +233,7 @@ structure AbstractInitREventSpec (AM) [Machine ACTX AM]
       → Machine.invariant (unlift default am' default x)
 
 @[simp]
-def AbstractInitREventSpec.to_InitEvent [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def AbstractInitREventSpec.to_InitEvent [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : InitEvent AM α β) (ev : AbstractInitREventSpec AM M abs) : _InitEvent M α β :=
   {
     guard := fun x => abs.guard x
@@ -245,7 +245,7 @@ def AbstractInitREventSpec.to_InitEvent [Machine ACTX AM] [Machine CTX M] [Refin
 Parameter `abs` is the event to reuse  (event of abstract machine)
 Parameter `ev` is the reuse specification (cf. `AbstractInitREventSpec`). -/
 @[simp]
-def newAbstractInitREvent [Machine ACTX AM] [Machine CTX M] [instR:Refinement AM M]
+def newAbstractInitREvent [@Machine ACTX AM] [@Machine CTX M] [instR:Refinement AM M]
   (abs : InitEvent AM α β) (ev : AbstractInitREventSpec AM M abs) : InitREvent AM M α β :=
   {
     to_InitEvent := ev.to_InitEvent
@@ -269,13 +269,13 @@ def newAbstractInitREvent [Machine ACTX AM] [Machine CTX M] [instR:Refinement AM
 
 /-- Variant of `newAbstractInitREvent` with implicit `Unit` output type -/
 @[simp]
-def newAbstractInitREvent' [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newAbstractInitREvent' [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : InitEvent AM α Unit) (ev : AbstractInitREventSpec AM M abs) : InitREvent AM M α Unit :=
   newAbstractInitREvent abs ev
 
 /-- Variant of `AbstractInitREventSpec` with implicit `Unit` input and output types -/
-structure AbstractInitREventSpec'' (AM) [Machine ACTX AM]
-                                 (M) [Machine CTX M]
+structure AbstractInitREventSpec'' (AM) [@Machine ACTX AM]
+                                 (M) [@Machine CTX M]
                                  [Refinement AM M]
   (abstract : InitEvent AM Unit Unit)
        extends _AbstractREventSpec'' AM M where
@@ -292,7 +292,7 @@ structure AbstractInitREventSpec'' (AM) [Machine ACTX AM]
       → Machine.invariant (unlift default am' default)
 
 @[simp]
-def AbstractInitREventSpec''.toAbstractInitREventSpec [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def AbstractInitREventSpec''.toAbstractInitREventSpec [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
     (abs : InitEvent AM Unit Unit) (ev : AbstractInitREventSpec'' AM M abs) : AbstractInitREventSpec AM M abs :=
   {
     to__AbstractREventSpec := ev.to__AbstractREventSpec
@@ -303,7 +303,7 @@ def AbstractInitREventSpec''.toAbstractInitREventSpec [Machine ACTX AM] [Machine
 
 /-- Variant of `newAbstractInitREvent` with implicit `Unit` input and output types -/
 @[simp]
-def newAbstractRInitEvent'' [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newAbstractRInitEvent'' [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : InitEvent AM Unit Unit) (ev : AbstractInitREventSpec'' AM M abs) : InitREvent AM M Unit Unit :=
   newAbstractInitREvent abs ev.toAbstractInitREventSpec
 
@@ -316,8 +316,8 @@ The requirements are thow of `AbstractREventSpec` with a demonstration
 that the abstract variant is preserved when reflected at the concrete level. -/
 structure AbstractAnticipatedREventSpec
               (v) [Preorder v]
-              (AM) [Machine ACTX AM]
-              (M) [Machine CTX M]
+              (AM) [@Machine ACTX AM]
+              (M) [@Machine CTX M]
               [Refinement AM M]
   {α β} (abstract : AnticipatedEvent v AM α β)
           extends AbstractREventSpec AM M abstract.toOrdinaryEvent where
@@ -336,8 +336,8 @@ Parameter `abs` is the event to reuse  (event of abstract machine)
 Parameter `ev` is the reuse specification (cf. `AbstractREventSpec`). -/
 @[simp]
 def newAbstractAnticipatedREvent [Preorder v]
-                                 [Machine ACTX AM]
-                                 [Machine CTX M]
+                                 [@Machine ACTX AM]
+                                 [@Machine CTX M]
                                  [instR:Refinement AM M]
   (abs : AnticipatedEvent v AM α β) (ev : AbstractAnticipatedREventSpec v AM M abs) : AnticipatedREvent v AM M α β :=
   let oev := newAbstractREvent abs.toOrdinaryEvent ev.toAbstractREventSpec
@@ -370,8 +370,8 @@ def newAbstractAnticipatedREvent [Preorder v]
 /-- Variant of `newAbstractAnticipatedREvent` with implicit `Unit` output type -/
 @[simp]
 def newAbstractAnticipatedREvent' [Preorder v]
-                                  [Machine ACTX AM]
-                                  [Machine CTX M]
+                                  [@Machine ACTX AM]
+                                  [@Machine CTX M]
                                   [Refinement AM M]
   (abs : AnticipatedEvent v AM α Unit) (ev : AbstractAnticipatedREventSpec v AM M abs) : AnticipatedREvent v AM M α Unit :=
   newAbstractAnticipatedREvent abs ev
@@ -379,8 +379,8 @@ def newAbstractAnticipatedREvent' [Preorder v]
 /-- Variant of `AbstractAnticipatedREventSpec` with implicit `Unit` input and output types -/
 structure AbstractAnticipatedREventSpec''
               (v) [Preorder v]
-              (AM) [Machine ACTX AM]
-              (M) [Machine CTX M]
+              (AM) [@Machine ACTX AM]
+              (M) [@Machine CTX M]
               [Refinement AM M]
   (abstract : AnticipatedEvent v AM Unit Unit)
           extends AbstractREventSpec'' AM M abstract.toOrdinaryEvent where
@@ -394,7 +394,7 @@ structure AbstractAnticipatedREventSpec''
       = abstract.po.variant am'
 
 @[simp]
-def AbstractAnticipatedREventSpec''.toAbstractAnticipatedREventSpec [Preorder v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def AbstractAnticipatedREventSpec''.toAbstractAnticipatedREventSpec [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : AnticipatedEvent v AM Unit Unit) (ev : AbstractAnticipatedREventSpec'' v AM M abs) : AbstractAnticipatedREventSpec v AM M abs :=
   {
     to__AbstractREventSpec := ev.to__AbstractREventSpec
@@ -407,8 +407,8 @@ def AbstractAnticipatedREventSpec''.toAbstractAnticipatedREventSpec [Preorder v]
 /-- Variant of `newAbstractAnticipatedREvent` with implicit `Unit` output type -/
 @[simp]
 def newAbstractAnticipatedREvent'' [Preorder v]
-                                  [Machine ACTX AM]
-                                  [Machine CTX M]
+                                  [@Machine ACTX AM]
+                                  [@Machine CTX M]
                                   [Refinement AM M]
   (abs : AnticipatedEvent v AM Unit Unit) (ev : AbstractAnticipatedREventSpec'' v AM M abs) : AnticipatedREvent v AM M Unit Unit :=
   newAbstractAnticipatedREvent abs ev.toAbstractAnticipatedREventSpec
@@ -418,8 +418,8 @@ Parameter `abs` is the event to reuse  (event of abstract machine)
 Parameter `ev` is the reuse specification (cf. `AbstractREventSpec`). -/
 @[simp]
 def newAbstractConvergentREvent  [Preorder v] [WellFoundedLT v]
-                                 [Machine ACTX AM]
-                                 [Machine CTX M]
+                                 [@Machine ACTX AM]
+                                 [@Machine CTX M]
                                  [instR:Refinement AM M]
   (abs : ConvergentEvent v AM α β) (ev : AbstractAnticipatedREventSpec v AM M abs.toAnticipatedEvent) : ConvergentREvent v AM M α β :=
   let oev := newAbstractAnticipatedREvent abs.toAnticipatedEvent ev
@@ -452,8 +452,8 @@ def newAbstractConvergentREvent  [Preorder v] [WellFoundedLT v]
 /-- Variant of `newAbstractConvergentREvent` with implicit `Unit` output type -/
 @[simp]
 def newAbstractConvergentREvent'  [Preorder v] [WellFoundedLT v]
-                                  [Machine ACTX AM]
-                                  [Machine CTX M]
+                                  [@Machine ACTX AM]
+                                  [@Machine CTX M]
                                   [Refinement AM M]
   (abs : ConvergentEvent v AM α Unit) (ev : AbstractAnticipatedREventSpec v AM M abs.toAnticipatedEvent) : ConvergentREvent v AM M α Unit :=
   newAbstractConvergentREvent abs ev
@@ -461,8 +461,8 @@ def newAbstractConvergentREvent'  [Preorder v] [WellFoundedLT v]
 /-- Variant of `newAbstractConvergentREvent` with implicit `Unit` input and output types -/
 @[simp]
 def newAbstractConvergentREvent''  [Preorder v] [WellFoundedLT v]
-                                   [Machine ACTX AM]
-                                   [Machine CTX M]
+                                   [@Machine ACTX AM]
+                                   [@Machine CTX M]
                                    [Refinement AM M]
   (abs : ConvergentEvent v AM Unit Unit) (ev : AbstractAnticipatedREventSpec'' v AM M abs.toAnticipatedEvent) : ConvergentREvent v AM M Unit Unit :=
   newAbstractConvergentREvent abs ev.toAbstractAnticipatedREventSpec

--- a/LeanMachines/Refinement/Relational/Basic.lean
+++ b/LeanMachines/Refinement/Relational/Basic.lean
@@ -33,9 +33,9 @@ of an abstract machine type `AM` (in context `ACTX`) by
 -/
 
 class Refinement {ACTX : outParam (Type u₁)} (AM)
-                 [Machine ACTX AM]
+                 [@Machine ACTX AM]
                  {CTX : outParam (Type u₂)} (M)
-                 [Machine CTX M] where
+                 [@Machine CTX M] where
 
   /-- The relation between the abstract machine type `AM` and
    the concrete machine type `M`, defined as a type-theoretic proposition. -/
@@ -58,7 +58,7 @@ open Refinement
 -/
 
 /-- Internal representation of proof obligations for ordinary events. -/
-structure _REventPO  [Machine ACTX AM] [Machine CTX M] [instR: Refinement AM M]
+structure _REventPO  [@Machine ACTX AM] [@Machine CTX M] [instR: Refinement AM M]
    (ev : _Event M α β) (kind : EventKind) (α' β')
    extends _EventPO ev kind where
 
@@ -94,12 +94,12 @@ Note that events, of type `OrdinaryREvent`, are not directly constructed using t
 structure. More user-friendly specification structures, such as `REventSpec`, and smart constructors,
  such as `newREvent` are preferably employed in practice.
  -/
-structure OrdinaryREvent (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR: Refinement AM M]
+structure OrdinaryREvent (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instR: Refinement AM M]
   (α β) (α':=α) (β':=β) extends _Event M α β where
   po : _REventPO (instR:=instR) to_Event (EventKind.TransDet Convergence.Ordinary) α' β'
 
 @[simp]
-def OrdinaryREvent.toOrdinaryEvent [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def OrdinaryREvent.toOrdinaryEvent [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (ev : OrdinaryREvent AM M α β α' β') : OrdinaryEvent M α β :=
   {
     to_Event := ev.to_Event
@@ -120,7 +120,7 @@ The input and output types can be lifted to the abstract, if needed,
 The proof obligations, beyond `safety` (of abstract events) are guard `strengthening`
 and abstract event `simulation`.
  -/
-structure REventSpec (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR: Refinement AM M]
+structure REventSpec (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instR: Refinement AM M]
   {α β α' β'} (abs : OrdinaryEvent AM α' β')
   extends EventSpec M α β where
 
@@ -154,7 +154,7 @@ with: `abs` the (ordinary) event to refine, and
   `ev` the refined event specification (cf. `REventSpec`).
 -/
 @[simp]
-def newREvent [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newREvent [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryEvent AM α' β') (ev : REventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : OrdinaryREvent AM M α β α' β' :=
   {
     to_Event := ev.to_Event
@@ -167,7 +167,7 @@ def newREvent [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
   }
 
 /-- Variant of `REventSpec` with implicit `Unit` output type -/
-structure REventSpec' (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR: Refinement AM M]
+structure REventSpec' (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instR: Refinement AM M]
   {α α'} (abstract : OrdinaryEvent AM α' Unit)
   extends EventSpec' M α where
 
@@ -188,7 +188,7 @@ structure REventSpec' (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR: Refinem
         refine am' m'
 
 @[simp]
-def REventSpec'.toREventSpec [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def REventSpec'.toREventSpec [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryEvent AM α' Unit) (ev : REventSpec' AM M (α:=α) (α':=α') abs) : REventSpec AM M (α:=α) (β:=Unit) (α':=α') (β':=Unit) abs :=
   {
     toEventSpec := ev.toEventSpec
@@ -200,12 +200,12 @@ def REventSpec'.toREventSpec [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
 
 /-- Variant of `newREvent` with implicit `Unit` output type -/
 @[simp]
-def newREvent' [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newREvent' [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryEvent AM α' Unit) (ev : REventSpec' AM M (α:=α) (α':=α') abs) : OrdinaryREvent AM M α Unit α' Unit :=
   newREvent abs ev.toREventSpec
 
 /-- Variant of `REventSpec` with implicit `Unit` input and output types -/
-structure REventSpec'' (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR: Refinement AM M]
+structure REventSpec'' (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instR: Refinement AM M]
   (abstract : OrdinaryEvent AM Unit Unit)
   extends EventSpec'' M where
 
@@ -224,7 +224,7 @@ structure REventSpec'' (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR: Refine
         refine am' m'
 
 @[simp]
-def REventSpec''.toREventSpec [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def REventSpec''.toREventSpec [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryEvent AM Unit Unit) (ev : REventSpec'' AM M abs) : REventSpec AM M (α:=Unit) (β:=Unit) (α':=Unit) (β':=Unit) abs :=
   {
     toEventSpec := ev.toEventSpec
@@ -236,7 +236,7 @@ def REventSpec''.toREventSpec [Machine ACTX AM] [Machine CTX M] [Refinement AM M
 
 /-- Variant of `newREvent` with implicit `Unit` input and output types -/
 @[simp]
-def newREvent'' [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newREvent'' [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryEvent AM Unit Unit) (ev : REventSpec'' AM M abs) : OrdinaryREvent AM M Unit Unit :=
   newREvent abs ev.toREventSpec
 
@@ -245,7 +245,7 @@ def newREvent'' [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
 -/
 
 /-- Internal representation of proof obligations for ordinary initialization events. -/
-structure _InitREventPO  [Machine ACTX AM] [Machine CTX M] [instR: Refinement AM M]
+structure _InitREventPO  [@Machine ACTX AM] [@Machine CTX M] [instR: Refinement AM M]
    (ev : _InitEvent M α β) (kind : EventKind) (α' β')
    extends _InitEventPO ev kind where
 
@@ -268,13 +268,13 @@ structure _InitREventPO  [Machine ACTX AM] [Machine CTX M] [instR: Refinement AM
 with: `AM` the abstact machine type, `M` the concrete maching type,
  `α` the concrete input parameter type, `α'` the corresponding abstract input type (by default, `α`)
  `β` the concrete input parameter type, `β'` the corresponding abstract input type (by default, `β`) -/
-structure InitREvent (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR: Refinement AM M]
+structure InitREvent (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instR: Refinement AM M]
   (α) (β) (α':=α) (β':=β)
   extends _InitEvent M α β where
   po : _InitREventPO (instR:=instR) to_InitEvent (EventKind.InitDet) α' β'
 
 @[simp]
-def InitREvent.toInitEvent [Machine ACTX AM] [Machine CTX M] [Refinement AM M] (ev : InitREvent AM M α β α' β') : InitEvent M α β :=
+def InitREvent.toInitEvent [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M] (ev : InitREvent AM M α β α' β') : InitEvent M α β :=
 {
   to_InitEvent:= ev.to_InitEvent
   po := ev.po.to_InitEventPO
@@ -287,7 +287,7 @@ and abstract event `simulation`.
 The input and output types can be lifted to the abstract, if needed,
  using the `lift_in` and `lift_out` components.
  -/
-structure InitREventSpec (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR: Refinement AM M]
+structure InitREventSpec (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instR: Refinement AM M]
   {α β α' β'} (abstract : InitEvent AM α' β')
   extends InitEventSpec M α β where
 
@@ -309,7 +309,7 @@ with: `abs` the (ordinary) event to refine, and
   `ev` the refined event specification (cf. `InitREventSpec`).
 -/
 @[simp]
-def newInitREvent [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newInitREvent [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : InitEvent AM α' β')
   (ev : InitREventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : InitREvent AM M α β α' β' :=
   {
@@ -336,7 +336,7 @@ def newInitREvent [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
   }
 
 /-- Variant of `InitREventSpec` with implicit `Unit` output type -/
-structure InitREventSpec' (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR: Refinement AM M]
+structure InitREventSpec' (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instR: Refinement AM M]
   {α α'} (abstract : InitEvent AM α' Unit)
   extends InitEventSpec' M α where
 
@@ -353,7 +353,7 @@ structure InitREventSpec' (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR: Ref
       refine am' m'
 
 @[simp]
-def InitREventSpec'.toInitREventSpec [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def InitREventSpec'.toInitREventSpec [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : InitEvent AM α' Unit) (ev : InitREventSpec' AM M (α:=α) (α':=α') abs) : InitREventSpec AM M (α:=α) (β:=Unit) (α':=α') (β':=Unit) abs :=
   {
     toInitEventSpec := ev.toInitEventSpec
@@ -365,13 +365,13 @@ def InitREventSpec'.toInitREventSpec [Machine ACTX AM] [Machine CTX M] [Refineme
 
 /-- Variant of `newInitREvent` with implicit `Unit` output type -/
 @[simp]
-def newInitREvent' [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newInitREvent' [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : InitEvent AM α' Unit)
   (ev : InitREventSpec' AM M (α:=α) (α':=α') abs) : InitREvent AM M α Unit α' Unit :=
   newInitREvent abs ev.toInitREventSpec
 
 /-- Variant of `InitREventSpec` with implicit `Unit` input and output types -/
-structure InitREventSpec'' (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR: Refinement AM M]
+structure InitREventSpec'' (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instR: Refinement AM M]
   (abstract : InitEvent AM Unit Unit)
   extends InitEventSpec'' M where
 
@@ -386,7 +386,7 @@ structure InitREventSpec'' (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR: Re
       refine am' m'
 
 @[simp]
-def InitREventSpec''.toInitREventSpec [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def InitREventSpec''.toInitREventSpec [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : InitEvent AM Unit Unit) (ev : InitREventSpec'' AM M abs) : InitREventSpec AM M (α:=Unit) (β:=Unit) (α':=Unit) (β':=Unit) abs :=
   {
     toInitEventSpec := ev.toInitEventSpec
@@ -398,7 +398,7 @@ def InitREventSpec''.toInitREventSpec [Machine ACTX AM] [Machine CTX M] [Refinem
 
 /-- Variant of `newREvent` with implicit `Unit` input and output types -/
 @[simp]
-def newInitREvent'' [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newInitREvent'' [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : InitEvent AM Unit Unit)
   (ev : InitREventSpec'' AM M abs) : InitREvent AM M Unit Unit :=
   newInitREvent abs ev.toInitREventSpec

--- a/LeanMachines/Refinement/Relational/Concrete.lean
+++ b/LeanMachines/Refinement/Relational/Concrete.lean
@@ -40,8 +40,8 @@ open Refinement
 -/
 
 /-- The specification of a concrete (ordinary) event, refining (non-deterministic) Skip.-/
-structure ConcreteREventSpec (AM) [instAM: Machine ACTX AM]
-                             (M) [instM: Machine CTX M]
+structure ConcreteREventSpec (AM) [instAM:@Machine ACTX AM]
+                             (M) [instM:@Machine CTX M]
                             [instR: Refinement AM M] (α) (β)
           extends EventSpec M α β where
 
@@ -55,7 +55,7 @@ structure ConcreteREventSpec (AM) [instAM: Machine ACTX AM]
 
 /-- The construction of a concrete (ordinary) event from a `ConcreteREventSpec` specification. -/
 @[simp]
-def newConcreteREvent [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newConcreteREvent [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
    (ev : ConcreteREventSpec AM M α β) : OrdinaryRDetEvent AM M α β :=
   {
     to_Event := ev.to_Event
@@ -74,8 +74,8 @@ def newConcreteREvent [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
 -/
 
 /-- Variant of `ConcreteREventSpec` with implicit `Unit` output type -/
-structure ConcreteREventSpec' (AM) [instAM: Machine ACTX AM]
-                             (M) [instM: Machine CTX M]
+structure ConcreteREventSpec' (AM) [instAM:@Machine ACTX AM]
+                             (M) [instM:@Machine CTX M]
                             [instR: Refinement AM M] (α)
           extends EventSpec' M α where
 
@@ -87,7 +87,7 @@ structure ConcreteREventSpec' (AM) [instAM: Machine ACTX AM]
 
 /-- Variant of `newConcreteREvent` with implicit `Unit` output type -/
 @[simp]
-def newConcreteREvent' [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newConcreteREvent' [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
    (ev : ConcreteREventSpec' AM M α) : OrdinaryRDetEvent AM M α Unit :=
   {
     to_Event := ev.toEventSpec.to_Event
@@ -102,8 +102,8 @@ def newConcreteREvent' [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
   }
 
 /-- Variant of `ConcreteREventSpec` with implicit `Unit` input and output types -/
-structure ConcreteREventSpec'' (AM) [instAM: Machine ACTX AM]
-                             (M) [instM: Machine CTX M]
+structure ConcreteREventSpec'' (AM) [instAM:@Machine ACTX AM]
+                             (M) [instM:@Machine CTX M]
                              [instR: Refinement AM M]
           extends EventSpec'' M where
 
@@ -115,7 +115,7 @@ structure ConcreteREventSpec'' (AM) [instAM: Machine ACTX AM]
 
 /-- Variant of `newConcreteREvent` with implicit `Unit` input and output types -/
 @[simp]
-def newConcreteREvent'' [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newConcreteREvent'' [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
    (ev : ConcreteREventSpec'' AM M) : OrdinaryRDetEvent AM M Unit Unit :=
   {
     to_Event := ev.toEventSpec.to_Event
@@ -163,8 +163,8 @@ for introducing new, concrete events in a refined machine.
 /-- The specification of a concrete anticipated event, with the requirements
 of `ConcreteREventSpec` together with anticipation requirements (variant, etc).-/
 structure ConcreteAnticipatedREventSpec (v) [Preorder v] [WellFoundedLT v]
-                             (AM) [instAM: Machine ACTX AM]
-                             (M) [instM: Machine CTX M]
+                             (AM) [instAM:@Machine ACTX AM]
+                             (M) [instM:@Machine CTX M]
                             [instR: Refinement AM M] (α) (β)
           extends _Variant (M:=M) v, ConcreteREventSpec AM M α β where
 
@@ -178,7 +178,7 @@ structure ConcreteAnticipatedREventSpec (v) [Preorder v] [WellFoundedLT v]
 /-- The construction of a concrete anticipated event from a `ConcreteAnticipatedREventSpec` specification. -/
 @[simp]
 def newConcreteAnticipatedREvent [Preorder v] [WellFoundedLT v]
-                       [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+                       [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
    (ev : ConcreteAnticipatedREventSpec v AM M α β) : AnticipatedRDetEvent v AM M α β :=
   {
     to_Event := ev.to_Event
@@ -199,8 +199,8 @@ def newConcreteAnticipatedREvent [Preorder v] [WellFoundedLT v]
 
 /-- Variant of `ConcreteAnticipatedREventSpec` with implicit `Unit` output type -/
 structure ConcreteAnticipatedREventSpec' (v) [Preorder v] [WellFoundedLT v]
-                             (AM) [instAM: Machine ACTX AM]
-                             (M) [instM: Machine CTX M]
+                             (AM) [instAM:@Machine ACTX AM]
+                             (M) [instM:@Machine CTX M]
                             [instR: Refinement AM M] (α)
           extends _Variant (M:=M) v, ConcreteREventSpec' AM M α where
 
@@ -213,7 +213,7 @@ structure ConcreteAnticipatedREventSpec' (v) [Preorder v] [WellFoundedLT v]
 /-- Variant of `newConcreteAnticipatedREvent` with implicit `Unit` output type -/
 @[simp]
 def newConcreteAnticipatedREvent' [Preorder v] [WellFoundedLT v]
-                       [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+                       [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
    (ev : ConcreteAnticipatedREventSpec' v AM M α) : AnticipatedRDetEvent v AM M α Unit :=
   {
     to_Event := ev.toEventSpec.to_Event
@@ -234,8 +234,8 @@ def newConcreteAnticipatedREvent' [Preorder v] [WellFoundedLT v]
 
 /-- Variant of `ConcreteAnticipatedREventSpec` with implicit `Unit` input and output types -/
 structure ConcreteAnticipatedREventSpec'' (v) [Preorder v] [WellFoundedLT v]
-                             (AM) [instAM: Machine ACTX AM]
-                             (M) [instM: Machine CTX M]
+                             (AM) [instAM:@Machine ACTX AM]
+                             (M) [instM:@Machine CTX M]
                              [instR: Refinement AM M]
           extends _Variant (M:=M) v, ConcreteREventSpec'' AM M where
 
@@ -248,7 +248,7 @@ structure ConcreteAnticipatedREventSpec'' (v) [Preorder v] [WellFoundedLT v]
 /-- Variant of `newConcreteAnticipatedREvent` with implicit `Unit` input and output types -/
 @[simp]
 def newConcreteAnticipatedREvent'' [Preorder v] [WellFoundedLT v]
-                       [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+                       [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
    (ev : ConcreteAnticipatedREventSpec'' v AM M) : AnticipatedRDetEvent v AM M Unit Unit :=
   {
     to_Event := ev.toEventSpec.to_Event
@@ -274,8 +274,8 @@ def newConcreteAnticipatedREvent'' [Preorder v] [WellFoundedLT v]
 /-- The specification of a concrete convergent event, with the requirements
 of `ConcreteREventSpec` together with convergence requirements (variant, etc).-/
 structure ConcreteConvergentREventSpec (v) [Preorder v] [WellFoundedLT v]
-                             (AM) [instAM: Machine ACTX AM]
-                             (M) [instM: Machine CTX M]
+                             (AM) [instAM:@Machine ACTX AM]
+                             (M) [instM:@Machine CTX M]
                             [instR: Refinement AM M] (α) (β)
           extends _Variant (M:=M) v, ConcreteREventSpec AM M α β where
 
@@ -289,7 +289,7 @@ structure ConcreteConvergentREventSpec (v) [Preorder v] [WellFoundedLT v]
 /-- The construction of a concrete convergent event from a `ConcreteConvergentREventSpec` specification. -/
 @[simp]
 def newConcreteConvergentREvent [Preorder v] [WellFoundedLT v]
-                       [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+                       [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
    (ev : ConcreteConvergentREventSpec v AM M α β) : ConvergentRDetEvent v AM M α β :=
   {
     to_Event := ev.to_Event
@@ -313,8 +313,8 @@ def newConcreteConvergentREvent [Preorder v] [WellFoundedLT v]
 
 /-- Variant of `ConcreteConvergentREventSpec` with implicit `Unit` output type -/
 structure ConcreteConvergentREventSpec' (v) [Preorder v] [WellFoundedLT v]
-                             (AM) [instAM: Machine ACTX AM]
-                             (M) [instM: Machine CTX M]
+                             (AM) [instAM:@Machine ACTX AM]
+                             (M) [instM:@Machine CTX M]
                             [instR: Refinement AM M] (α)
           extends _Variant (M:=M) v, ConcreteREventSpec' AM M α where
 
@@ -327,7 +327,7 @@ structure ConcreteConvergentREventSpec' (v) [Preorder v] [WellFoundedLT v]
 /-- Variant of `newConcreteConvergentREvent` with implicit `Unit` output type -/
 @[simp]
 def newConcreteConvergentREvent' [Preorder v] [WellFoundedLT v]
-                       [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+                       [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
    (ev : ConcreteConvergentREventSpec' v AM M α) : ConvergentRDetEvent v AM M α Unit :=
   {
     to_Event := ev.toEventSpec.to_Event
@@ -350,8 +350,8 @@ def newConcreteConvergentREvent' [Preorder v] [WellFoundedLT v]
 
 /-- Variant of `ConcreteConvergentREventSpec` with implicit `Unit` input and output types -/
 structure ConcreteConvergentREventSpec'' (v) [Preorder v] [WellFoundedLT v]
-                             (AM) [instAM: Machine ACTX AM]
-                             (M) [instM: Machine CTX M]
+                             (AM) [instAM:@Machine ACTX AM]
+                             (M) [instM:@Machine CTX M]
                              [instR: Refinement AM M]
           extends _Variant (M:=M) v, ConcreteREventSpec'' AM M where
 
@@ -364,7 +364,7 @@ structure ConcreteConvergentREventSpec'' (v) [Preorder v] [WellFoundedLT v]
 /-- Variant of `newConcreteConvergentREvent` with implicit `Unit` input and output types -/
 @[simp]
 def newConcreteConvergentREvent'' [Preorder v] [WellFoundedLT v]
-                       [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+                       [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
    (ev : ConcreteConvergentREventSpec'' v AM M) : ConvergentRDetEvent v AM M Unit Unit :=
   {
     to_Event := ev.toEventSpec.to_Event

--- a/LeanMachines/Refinement/Relational/Convergent.lean
+++ b/LeanMachines/Refinement/Relational/Convergent.lean
@@ -22,7 +22,7 @@ open Refinement
 -/
 
 /-- Internal representation of proof obligations for anticipated events -/
-structure _AnticipatedREventPO (v) [Preorder v]  [Machine ACTX AM] [instM:Machine CTX M] [instR: Refinement AM M]
+structure _AnticipatedREventPO (v) [Preorder v]  [@Machine ACTX AM] [instM:@Machine CTX M] [instR: Refinement AM M]
   (ev : _Event M α β) (kind : EventKind) (α') (β')
           extends _Variant v (instM:=instM), _REventPO (instR:=instR) ev kind α' β'  where
 
@@ -35,13 +35,13 @@ structure _AnticipatedREventPO (v) [Preorder v]  [Machine ACTX AM] [instM:Machin
 /-- The representation of anticipated refined events, constructed
 by specifications structures, e.g. `AnticipatedREventSpec`,
  and smart constructors, e.g. `newAnticipatedREvent`. -/
-structure AnticipatedREvent (v) [Preorder v] (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR: Refinement AM M]
+structure AnticipatedREvent (v) [Preorder v] (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instR: Refinement AM M]
   (α β) (α':=α) (β':=β)
   extends _Event M α β where
   po : _AnticipatedREventPO v (instR:=instR) to_Event (EventKind.TransDet Convergence.Anticipated) α' β'
 
 @[simp]
-def AnticipatedREvent.toAnticipatedEvent [Preorder v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def AnticipatedREvent.toAnticipatedEvent [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (ev : AnticipatedREvent v AM M α β α' β') : AnticipatedEvent v M α β :=
   { to_Event := ev.to_Event
     po := {
@@ -66,7 +66,7 @@ The input and output types can be lifted to the abstract, if needed,
 The added proof obligation, beyond `safety` , guard `strengthening`,
 abstract event `simulation`, is a `nonIncreasing` requirement.
  -/
-structure AnticipatedREventSpec (v) [Preorder v] (AM) [Machine ACTX AM] (M) [instM:Machine CTX M] [Refinement AM M]
+structure AnticipatedREventSpec (v) [Preorder v] (AM) [@Machine ACTX AM] (M) [instM:@Machine CTX M] [Refinement AM M]
   {α β α' β'} (abs : OrdinaryEvent AM α' β')
   extends _Variant v (instM:=instM), REventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abs where
 
@@ -78,7 +78,7 @@ structure AnticipatedREventSpec (v) [Preorder v] (AM) [Machine ACTX AM] (M) [ins
       variant m' ≤ variant m
 
 @[simp]
-private def _newAnticipatedREvent [Preorder v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+private def _newAnticipatedREvent [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryEvent AM α' β') (ev : AnticipatedREventSpec v AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : AnticipatedREvent v AM M α β α' β' :=
   {
     to_Event := ev.to_Event
@@ -100,7 +100,7 @@ with: `abs` the ordinary event to refine, and
   (cf. `AnticipatedREventSpec`).
 -/
 @[simp]
-def newAnticipatedREventfromOrdinary [Preorder v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newAnticipatedREventfromOrdinary [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryEvent AM α' β') (ev : AnticipatedREventSpec v AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : AnticipatedREvent v AM M α β α' β' :=
   _newAnticipatedREvent abs ev
 
@@ -111,12 +111,12 @@ with: `abs` the anticipated event to refine, and
 
 -/
 @[simp]
-def newAnticipatedREventfromAnticipated [Preorder v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newAnticipatedREventfromAnticipated [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : AnticipatedEvent v AM α' β') (ev : AnticipatedREventSpec v AM M (α:=α) (β:=β) (α':=α') (β':=β') abs.toOrdinaryEvent) : AnticipatedREvent v AM M α β α' β' :=
   _newAnticipatedREvent abs.toOrdinaryEvent ev
 
 /-- Variant of `AnticipatedREventSpec` with implicit `Unit` output type -/
-structure AnticipatedREventSpec' (v) [Preorder v] (AM) [Machine ACTX AM] (M) [instM:Machine CTX M] [Refinement AM M]
+structure AnticipatedREventSpec' (v) [Preorder v] (AM) [@Machine ACTX AM] (M) [instM:@Machine CTX M] [Refinement AM M]
   {α α'} (abs : OrdinaryEvent AM α' Unit)
   extends _Variant v (instM:=instM), REventSpec' AM M (α:=α) (α':=α') abs where
 
@@ -127,7 +127,7 @@ structure AnticipatedREventSpec' (v) [Preorder v] (AM) [Machine ACTX AM] (M) [in
       variant m' ≤ variant m
 
 @[simp]
-def AnticipatedREventSpec'.toAnticipatedREventSpec [Preorder v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def AnticipatedREventSpec'.toAnticipatedREventSpec [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryEvent AM α' Unit) (ev : AnticipatedREventSpec' v AM M (α:=α) (α':=α') abs) : AnticipatedREventSpec v AM M (α:=α) (β:=Unit) (α':=α') (β':=Unit) abs :=
   {
     toREventSpec := ev.toREventSpec abs
@@ -136,24 +136,24 @@ def AnticipatedREventSpec'.toAnticipatedREventSpec [Preorder v] [Machine ACTX AM
   }
 
 @[simp]
-private def _newAnticipatedREvent' [Preorder v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+private def _newAnticipatedREvent' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryEvent AM α' Unit) (ev : AnticipatedREventSpec' v AM M (α:=α) (α':=α') abs) : AnticipatedREvent v AM M α Unit α' Unit :=
   _newAnticipatedREvent abs ev.toAnticipatedREventSpec
 
 /-- Variant of `newAnticipatedREventFromOrdinary` with implicit `Unit` output type -/
 @[simp]
-def newAnticipatedREventfromOrdinary' [Preorder v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newAnticipatedREventfromOrdinary' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryEvent AM α' Unit) (ev : AnticipatedREventSpec' v AM M (α:=α) (α':=α') abs) : AnticipatedREvent v AM M α Unit α' Unit :=
   _newAnticipatedREvent' abs ev
 
 /-- Variant of `newAnticipatedREventFromAnticipated` with implicit `Unit` output type -/
 @[simp]
-def newAnticipatedREventfromAnticipated' [Preorder v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newAnticipatedREventfromAnticipated' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : AnticipatedEvent v AM α' Unit) (ev : AnticipatedREventSpec' v AM M (α:=α) (α':=α') abs.toOrdinaryEvent) : AnticipatedREvent v AM M α Unit α' Unit :=
   _newAnticipatedREvent' abs.toOrdinaryEvent ev
 
 /-- Variant of `AnticipatedREventSpec` with implicit `Unit` input and output types -/
-structure AnticipatedREventSpec'' (v) [Preorder v] (AM) [Machine ACTX AM] (M) [instM:Machine CTX M] [Refinement AM M]
+structure AnticipatedREventSpec'' (v) [Preorder v] (AM) [@Machine ACTX AM] (M) [instM:@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryEvent AM Unit Unit)
   extends _Variant v (instM:=instM), REventSpec'' AM M abs where
 
@@ -164,7 +164,7 @@ structure AnticipatedREventSpec'' (v) [Preorder v] (AM) [Machine ACTX AM] (M) [i
       variant m' ≤ variant m
 
 @[simp]
-def AnticipatedREventSpec''.toAnticipatedREventSpec [Preorder v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def AnticipatedREventSpec''.toAnticipatedREventSpec [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryEvent AM Unit Unit) (ev : AnticipatedREventSpec'' v AM M abs) : AnticipatedREventSpec v AM M (α:=Unit) (β:=Unit) (α':=Unit) (β':=Unit) abs :=
   {
     toREventSpec := ev.toREventSpec abs
@@ -173,19 +173,19 @@ def AnticipatedREventSpec''.toAnticipatedREventSpec [Preorder v] [Machine ACTX A
   }
 
 @[simp]
-private def _newAnticipatedREvent'' [Preorder v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+private def _newAnticipatedREvent'' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryEvent AM Unit Unit) (ev : AnticipatedREventSpec'' v AM M abs) : AnticipatedREvent v AM M Unit Unit :=
   _newAnticipatedREvent abs ev.toAnticipatedREventSpec
 
 /-- Variant of `newAnticipatedREventfromOrdinary` with implicit `Unit` input and output types -/
 @[simp]
-def newAnticipatedREventfromOrdinary'' [Preorder v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newAnticipatedREventfromOrdinary'' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryEvent AM Unit Unit) (ev : AnticipatedREventSpec'' v AM M abs) : AnticipatedREvent v AM M Unit Unit :=
   _newAnticipatedREvent'' abs ev
 
 /-- Variant of `newAnticipatedREventfromAnticipated` with implicit `Unit` input and output types -/
 @[simp]
-def newAnticipatedREventfromAnticipated'' [Preorder v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newAnticipatedREventfromAnticipated'' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : AnticipatedEvent v AM Unit Unit) (ev : AnticipatedREventSpec'' v AM M abs.toOrdinaryEvent) : AnticipatedREvent v AM M Unit Unit :=
   _newAnticipatedREvent'' abs.toOrdinaryEvent ev
 
@@ -194,7 +194,7 @@ def newAnticipatedREventfromAnticipated'' [Preorder v] [Machine ACTX AM] [Machin
 -/
 
 /-- Internal representation of proof obligations for convergent refined events -/
-structure _ConvergentREventPO (v) [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [instR: Refinement AM M]
+structure _ConvergentREventPO (v) [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [instR: Refinement AM M]
   (ev : _Event M α β) (kind : EventKind) (α') (β')
   extends _AnticipatedREventPO (instR:=instR) v ev kind α' β' where
 
@@ -207,13 +207,13 @@ structure _ConvergentREventPO (v) [Preorder v] [WellFoundedLT v] [Machine ACTX A
 /-- The representation of convergent refined events, constructed
 by specifications structures, e.g. `ConvergentREventSpec`,
  and smart constructors, e.g. `newConvergentREvent`. -/
-structure ConvergentREvent (v) [Preorder v] [WellFoundedLT v] (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR: Refinement AM M]
+structure ConvergentREvent (v) [Preorder v] [WellFoundedLT v] (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instR: Refinement AM M]
   (α β) (α':=α) (β':=β)
   extends _Event M α β where
   po : _ConvergentREventPO v (instR:=instR) to_Event (EventKind.TransDet Convergence.Convergent) α' β'
 
 @[simp]
-def ConvergentREvent.toConvergentEvent [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def ConvergentREvent.toConvergentEvent [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (ev : ConvergentREvent v AM M α β α' β') : ConvergentEvent v M α β :=
   { to_Event := ev.to_Event
     po := {
@@ -236,7 +236,7 @@ The input and output types can be lifted to the abstract, if needed,
 The added proof obligation, beyond `safety` , guard `strengthening`,
 abstract event `simulation`, is a `convergence` requirement.
  -/
-structure ConvergentREventSpec (v) [Preorder v] [WellFoundedLT v] (AM) [Machine ACTX AM] (M) [instM:Machine CTX M] [Refinement AM M]
+structure ConvergentREventSpec (v) [Preorder v] [WellFoundedLT v] (AM) [@Machine ACTX AM] (M) [instM:@Machine CTX M] [Refinement AM M]
   {α β α' β'} (abs : OrdinaryEvent AM α' β')
   extends _Variant v (instM:=instM), REventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abs where
 
@@ -252,7 +252,7 @@ with: `abs` the event to refine, and
   `ev` the refined event specification (cf. `ConvergentREventSpec`).
 -/
 @[simp]
-def newConvergentREvent [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newConvergentREvent [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryEvent AM α' β') (ev : ConvergentREventSpec v AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : ConvergentREvent v AM M α β α' β':=
   {
     guard := ev.guard
@@ -276,7 +276,7 @@ def newConvergentREvent [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machin
   }
 
 /-- Variant of `ConvergentREventSpec` with implicit `Unit` output type -/
-structure ConvergentREventSpec' (v) [Preorder v] [WellFoundedLT v] (AM) [Machine ACTX AM] (M) [instM:Machine CTX M] [Refinement AM M]
+structure ConvergentREventSpec' (v) [Preorder v] [WellFoundedLT v] (AM) [@Machine ACTX AM] (M) [instM:@Machine CTX M] [Refinement AM M]
   {α α'} (abs : OrdinaryEvent AM α' Unit)
   extends _Variant v (instM:=instM), REventSpec' AM M (α:=α) (α':=α') abs where
 
@@ -287,7 +287,7 @@ structure ConvergentREventSpec' (v) [Preorder v] [WellFoundedLT v] (AM) [Machine
       variant m' < variant m
 
 @[simp]
-def ConvergentREventSpec'.toConvergentREventSpec [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def ConvergentREventSpec'.toConvergentREventSpec [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryEvent AM α' Unit) (ev : ConvergentREventSpec' v AM M (α:=α) (α':=α') abs) : ConvergentREventSpec v AM M (α:=α) (β:=Unit) (α':=α') (β':=Unit) abs :=
   {
     toREventSpec := ev.toREventSpec abs
@@ -297,12 +297,12 @@ def ConvergentREventSpec'.toConvergentREventSpec [Preorder v] [WellFoundedLT v] 
 
 /-- Variant of `newConvergentREvent` with implicit `Unit` output type -/
 @[simp]
-def newConvergentREvent' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newConvergentREvent' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryEvent AM α' Unit) (ev : ConvergentREventSpec' v AM M (α:=α) (α':=α') abs) : ConvergentREvent v AM M α Unit α' Unit :=
   newConvergentREvent abs ev.toConvergentREventSpec
 
 /-- Variant of `ConvergentREventSpec` with implicit `Unit` input and output types -/
-structure ConvergentREventSpec'' (v) [Preorder v] [WellFoundedLT v] (AM) [Machine ACTX AM] (M) [instM:Machine CTX M] [Refinement AM M]
+structure ConvergentREventSpec'' (v) [Preorder v] [WellFoundedLT v] (AM) [@Machine ACTX AM] (M) [instM:@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryEvent AM Unit Unit)
   extends _Variant v (instM:=instM), REventSpec'' AM M abs where
 
@@ -313,7 +313,7 @@ structure ConvergentREventSpec'' (v) [Preorder v] [WellFoundedLT v] (AM) [Machin
       variant m' < variant m
 
 @[simp]
-def ConvergentREventSpec''.toConvergentREventSpec [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def ConvergentREventSpec''.toConvergentREventSpec [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryEvent AM Unit Unit) (ev : ConvergentREventSpec'' v AM M abs) : ConvergentREventSpec v AM M (α:=Unit) (β:=Unit) (α':=Unit) (β':=Unit) abs :=
   {
     toREventSpec := ev.toREventSpec abs
@@ -323,6 +323,6 @@ def ConvergentREventSpec''.toConvergentREventSpec [Preorder v] [WellFoundedLT v]
 
 /-- Variant of `newConvergentREvent` with implicit `Unit` input and output types -/
 @[simp]
-def newConvergentREvent'' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newConvergentREvent'' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryEvent AM Unit Unit) (ev : ConvergentREventSpec'' v AM M abs) : ConvergentREvent v AM M Unit Unit :=
   newConvergentREvent abs ev.toConvergentREventSpec

--- a/LeanMachines/Refinement/Relational/NonDet/Abstract.lean
+++ b/LeanMachines/Refinement/Relational/NonDet/Abstract.lean
@@ -29,8 +29,8 @@ open Refinement
 
 /-- Reuse of abstract events: the `lift/unlift` part specific to non-determinism.
 (machine-level properties are the same as in the deterministic case). -/
-structure _AbstractRNDEventSpec (AM) [Machine ACTX AM]
-                               (M) [Machine CTX M]
+structure _AbstractRNDEventSpec (AM) [@Machine ACTX AM]
+                               (M) [@Machine CTX M]
                                [Refinement AM M] (α)
           extends _AbstractREventSpec AM M α where
 
@@ -43,8 +43,8 @@ structure _AbstractRNDEventSpec (AM) [Machine ACTX AM]
 /-- The specification of the reuse of an `abstract` non-deterministic
 event, with the `lift` and `unlift` operations, the associated proof obligations,
  and the further two event-level proof obligations specific to non-determinism. -/
-structure AbstractRNDEventSpec (AM) [Machine ACTX AM]
-                               (M) [Machine CTX M]
+structure AbstractRNDEventSpec (AM) [@Machine ACTX AM]
+                               (M) [@Machine CTX M]
                                [Refinement AM M]
   {α β} (abstract : OrdinaryNDEvent AM α β)
           extends _AbstractRNDEventSpec AM M α where
@@ -67,7 +67,7 @@ structure AbstractRNDEventSpec (AM) [Machine ACTX AM]
 Parameter `abs` is the event to reuse  (event of abstract machine)
 Parameter `ev` is the reuse specification (cf. `AbstractRNDEventSpec`). -/
 @[simp]
-def newAbstractRNDEvent [Machine ACTX AM] [Machine CTX M] [instR:Refinement AM M]
+def newAbstractRNDEvent [@Machine ACTX AM] [@Machine CTX M] [instR:Refinement AM M]
   (abs : OrdinaryNDEvent AM α β) (ev : AbstractRNDEventSpec AM M abs) : OrdinaryRNDEvent AM M α β :=
   {
     guard := fun m x => abs.guard (ev.lift m) x
@@ -128,8 +128,8 @@ def newAbstractRNDEvent [Machine ACTX AM] [Machine CTX M] [instR:Refinement AM M
   }
 
 /-- Variant of `AbstractRNDEventSpec` with implicit `Unit` input type -/
-structure AbstractRNDEventSpec' (AM) [Machine ACTX AM]
-                               (M) [Machine CTX M]
+structure AbstractRNDEventSpec' (AM) [@Machine ACTX AM]
+                               (M) [@Machine CTX M]
                                [Refinement AM M]
   {α} (abstract : OrdinaryNDEvent AM α Unit)
           extends _AbstractRNDEventSpec AM M α where
@@ -147,7 +147,7 @@ structure AbstractRNDEventSpec' (AM) [Machine ACTX AM]
              → Machine.invariant (unlift (lift m) am' m x)
 
 @[simp]
-def AbstractRNDEventSpec'.toAbstractRNDEventSpec [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def AbstractRNDEventSpec'.toAbstractRNDEventSpec [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
     (abs : OrdinaryNDEvent AM α Unit) (ev : AbstractRNDEventSpec' AM M abs) : AbstractRNDEventSpec AM M abs :=
   {
     to_AbstractRNDEventSpec := ev.to_AbstractRNDEventSpec
@@ -162,12 +162,12 @@ def AbstractRNDEventSpec'.toAbstractRNDEventSpec [Machine ACTX AM] [Machine CTX 
 
 /-- Variant of `newAbstractRNDEvent` with implicit `Unit` input type -/
 @[simp]
-def newAbstractRNDEvent' [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newAbstractRNDEvent' [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryNDEvent AM α Unit) (ev : AbstractRNDEventSpec' AM M abs) : OrdinaryRNDEvent AM M α Unit :=
   newAbstractRNDEvent abs ev.toAbstractRNDEventSpec
 
-structure _AbstractRNDEventSpec'' (AM) [Machine ACTX AM]
-                                  (M) [Machine CTX M]
+structure _AbstractRNDEventSpec'' (AM) [@Machine ACTX AM]
+                                  (M) [@Machine CTX M]
                                   [Refinement AM M]
           extends _AbstractREventSpec'' AM M where
 
@@ -177,8 +177,8 @@ structure _AbstractRNDEventSpec'' (AM) [Machine ACTX AM]
 
 
 /-- Variant of `AbstractRNDEventSpec` with implicit `Unit` input and output types -/
-structure AbstractRNDEventSpec'' (AM) [Machine ACTX AM]
-                                 (M) [Machine CTX M]
+structure AbstractRNDEventSpec'' (AM) [@Machine ACTX AM]
+                                 (M) [@Machine CTX M]
                                  [Refinement AM M]
   (abstract : OrdinaryNDEvent AM Unit Unit)
           extends _AbstractRNDEventSpec'' AM M where
@@ -196,7 +196,7 @@ structure AbstractRNDEventSpec'' (AM) [Machine ACTX AM]
              → Machine.invariant (unlift (lift m) am' m)
 
 @[simp]
-def AbstractRNDEventSpec''.toAbstractRNDEventSpec [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def AbstractRNDEventSpec''.toAbstractRNDEventSpec [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
     (abs : OrdinaryNDEvent AM Unit Unit) (ev : AbstractRNDEventSpec'' AM M abs) : AbstractRNDEventSpec AM M abs :=
   {
     to__AbstractREventSpec := ev.to__AbstractREventSpec
@@ -212,7 +212,7 @@ def AbstractRNDEventSpec''.toAbstractRNDEventSpec [Machine ACTX AM] [Machine CTX
 
 /-- Variant of `newAbstractRNDEvent` with implicit `Unit` input and output types -/
 @[simp]
-def newAbstractRNDEvent'' [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newAbstractRNDEvent'' [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryNDEvent AM Unit Unit) (ev : AbstractRNDEventSpec'' AM M abs) : OrdinaryRNDEvent AM M Unit Unit :=
   newAbstractRNDEvent abs ev.toAbstractRNDEventSpec
 
@@ -224,8 +224,8 @@ def newAbstractRNDEvent'' [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
 /-- The specification of the reuse of an `abstract` non-deterministic
 initialization event, with the `lift` and `unlift` operations,
 the associated proof obligations,  and further three event-level proof obligations. -/
-structure AbstractInitRNDEventSpec (AM) [Machine ACTX AM]
-                                   (M) [Machine CTX M]
+structure AbstractInitRNDEventSpec (AM) [@Machine ACTX AM]
+                                   (M) [@Machine CTX M]
                                   [Refinement AM M]
   {α β} (abstract : InitNDEvent AM α β)
           extends _AbstractREventSpec AM M α where
@@ -249,7 +249,7 @@ structure AbstractInitRNDEventSpec (AM) [Machine ACTX AM]
                   → Machine.invariant (unlift default am' default x)
 
 @[simp]
-def AbstractInitRNDEventSpec.to_InitNDEvent  [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def AbstractInitRNDEventSpec.to_InitNDEvent  [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : InitNDEvent AM α β) (ev : AbstractInitRNDEventSpec AM M abs) : _InitNDEvent M α β  :=
   {
     guard := abs.guard
@@ -261,7 +261,7 @@ def AbstractInitRNDEventSpec.to_InitNDEvent  [Machine ACTX AM] [Machine CTX M] [
 Parameter `abs` is the event to reuse  (event of abstract machine)
 Parameter `ev` is the reuse specification (cf. `AbstractInitRNDEventSpec`). -/
 @[simp]
-def newAbstractInitRNDEvent [Machine ACTX AM] [Machine CTX M] [instR:Refinement AM M]
+def newAbstractInitRNDEvent [@Machine ACTX AM] [@Machine CTX M] [instR:Refinement AM M]
   (abs : InitNDEvent AM α β) (ev : AbstractInitRNDEventSpec AM M abs) : InitRNDEvent AM M α β :=
   {
     to_InitNDEvent := ev.to_InitNDEvent
@@ -315,8 +315,8 @@ def newAbstractInitRNDEvent [Machine ACTX AM] [Machine CTX M] [instR:Refinement 
   }
 
 /-- Variant of `AbstractInitRNDEventSpec` with implicit `Unit` output type -/
-structure AbstractInitRNDEventSpec' (AM) [Machine ACTX AM]
-                                   (M) [Machine CTX M]
+structure AbstractInitRNDEventSpec' (AM) [@Machine ACTX AM]
+                                   (M) [@Machine CTX M]
                                   [Refinement AM M]
   {α} (abstract : InitNDEvent AM α Unit)
           extends _AbstractREventSpec AM M α where
@@ -337,7 +337,7 @@ structure AbstractInitRNDEventSpec' (AM) [Machine ACTX AM]
 
 /-- Variant of `AbstractInitRNDEventSpec` with implicit `Unit` output type -/
 @[simp]
-def AbstractInitRNDEventSpec'.toAbstractInitRNDEventSpec [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def AbstractInitRNDEventSpec'.toAbstractInitRNDEventSpec [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abstract : InitNDEvent AM α Unit)
   (ev : AbstractInitRNDEventSpec' AM M abstract) : AbstractInitRNDEventSpec AM M abstract :=
   {
@@ -353,13 +353,13 @@ def AbstractInitRNDEventSpec'.toAbstractInitRNDEventSpec [Machine ACTX AM] [Mach
 
 /-- Variant of `newAbstractInitRNDEvent` with implicit `Unit` output type -/
 @[simp]
-def newAbstractInitRNDEvent' [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newAbstractInitRNDEvent' [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : InitNDEvent AM α Unit) (ev : AbstractInitRNDEventSpec' AM M abs) : InitRNDEvent AM M α Unit :=
   newAbstractInitRNDEvent abs ev.toAbstractInitRNDEventSpec
 
 /-- Variant of `AbstractInitRNDEventSpec` with implicit `Unit` input and output types -/
-structure AbstractInitRNDEventSpec'' (AM) [Machine ACTX AM]
-                                     (M) [Machine CTX M]
+structure AbstractInitRNDEventSpec'' (AM) [@Machine ACTX AM]
+                                     (M) [@Machine CTX M]
                                      [Refinement AM M]
   (abstract : InitNDEvent AM Unit Unit)
           extends _AbstractREventSpec'' AM M where
@@ -379,7 +379,7 @@ structure AbstractInitRNDEventSpec'' (AM) [Machine ACTX AM]
              → Machine.invariant (unlift default am' default)
 
 @[simp]
-def AbstractInitRNDEventSpec''.toAbstractInitRNDEventSpec [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def AbstractInitRNDEventSpec''.toAbstractInitRNDEventSpec [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abstract : InitNDEvent AM Unit Unit)
   (ev : AbstractInitRNDEventSpec'' AM M abstract) : AbstractInitRNDEventSpec AM M abstract :=
   {
@@ -396,7 +396,7 @@ def AbstractInitRNDEventSpec''.toAbstractInitRNDEventSpec [Machine ACTX AM] [Mac
 
 /-- Variant of `newAbstractInitRNDEvent` with implicit `Unit` input and output types -/
 @[simp]
-def newAbstractInitRNDEvent'' [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newAbstractInitRNDEvent'' [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : InitNDEvent AM Unit Unit) (ev : AbstractInitRNDEventSpec'' AM M abs) : InitRNDEvent AM M Unit Unit :=
   newAbstractInitRNDEvent abs ev.toAbstractInitRNDEventSpec
 
@@ -407,7 +407,7 @@ def newAbstractInitRNDEvent'' [Machine ACTX AM] [Machine CTX M] [Refinement AM M
 /-- Reuse of an abstract anticipated event with `abs` a non-deterministic anticipated event.
 The requirements are those of `AbstractRNDEventSpec`. -/
 @[simp]
-def newAbstractAnticipatedRNDEvent [Preorder v] [Machine ACTX AM] [Machine CTX M] [instR:Refinement AM M]
+def newAbstractAnticipatedRNDEvent [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [instR:Refinement AM M]
   (abs : AnticipatedNDEvent v AM α β) (ev : AbstractRNDEventSpec AM M abs.toOrdinaryNDEvent) : AnticipatedRNDEvent v AM M α β :=
   let aev := newAbstractRNDEvent abs.toOrdinaryNDEvent ev
   {
@@ -432,20 +432,20 @@ def newAbstractAnticipatedRNDEvent [Preorder v] [Machine ACTX AM] [Machine CTX M
 
 /-- Variant of `newAbstractAnticipatedRNDEvent` with implicit `Unit` output type -/
 @[simp]
-def newAbstractAnticipatedRNDEvent' [Preorder v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newAbstractAnticipatedRNDEvent' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : AnticipatedNDEvent v AM α Unit) (ev : AbstractRNDEventSpec' AM M abs.toOrdinaryNDEvent) : AnticipatedRNDEvent v AM M α Unit :=
   newAbstractAnticipatedRNDEvent abs ev.toAbstractRNDEventSpec
 
 /-- Variant of `AbstractAnticipatedRNDEventSpec` with implicit `Unit` input and output types -/
 @[simp]
-def newAbstractAnticipatedRNDEvent'' [Preorder v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newAbstractAnticipatedRNDEvent'' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : AnticipatedNDEvent v AM Unit Unit) (ev : AbstractRNDEventSpec'' AM M abs.toOrdinaryNDEvent) : AnticipatedRNDEvent v AM M Unit Unit :=
   newAbstractAnticipatedRNDEvent abs ev.toAbstractRNDEventSpec
 
 /-- Reuse of an abstract convergent event with `abs` a non-deterministic convergent event.
 The requirements are those of `AbstractRNDEventSpec`. -/
 @[simp]
-def newAbstractConvergentRNDEvent [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [instR:Refinement AM M]
+def newAbstractConvergentRNDEvent [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [instR:Refinement AM M]
   (abs : ConvergentNDEvent v AM α β) (ev : AbstractRNDEventSpec AM M abs.toAnticipatedNDEvent.toOrdinaryNDEvent) : ConvergentRNDEvent v AM M α β :=
   let aev := newAbstractAnticipatedRNDEvent abs.toAnticipatedNDEvent ev
   {
@@ -470,12 +470,12 @@ def newAbstractConvergentRNDEvent [Preorder v] [WellFoundedLT v] [Machine ACTX A
 
 /-- Variant of `newAbstractConvergentRNDEvent` with implicit `Unit` output type. -/
 @[simp]
-def newAbstractConvergentRNDEvent' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newAbstractConvergentRNDEvent' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : ConvergentNDEvent v AM α Unit) (ev : AbstractRNDEventSpec' AM M abs.toAnticipatedNDEvent.toOrdinaryNDEvent) : ConvergentRNDEvent v AM M α Unit :=
   newAbstractConvergentRNDEvent abs ev.toAbstractRNDEventSpec
 
 /-- Variant of `newAbstractConvergentRNDEvent` with implicit `Unit` input and output types. -/
 @[simp]
-def newAbstractConvergentRNDEvent'' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newAbstractConvergentRNDEvent'' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : ConvergentNDEvent v AM Unit Unit) (ev : AbstractRNDEventSpec'' AM M abs.toAnticipatedNDEvent.toOrdinaryNDEvent) : ConvergentRNDEvent v AM M Unit Unit :=
   newAbstractConvergentRNDEvent abs ev.toAbstractRNDEventSpec

--- a/LeanMachines/Refinement/Relational/NonDet/Basic.lean
+++ b/LeanMachines/Refinement/Relational/NonDet/Basic.lean
@@ -18,7 +18,7 @@ for ordinary, non-deterministic events.
 -/
 
 /-- Internal representation of proof obligations for ordinary non-deterministic events. -/
-structure _RNDEventPO  [Machine ACTX AM] [Machine CTX M] [instR: Refinement AM M]
+structure _RNDEventPO  [@Machine ACTX AM] [@Machine CTX M] [instR: Refinement AM M]
    (ev : _NDEvent M α β) (kind : EventKind) (α' β')
    extends _NDEventPO ev kind where
 
@@ -50,12 +50,12 @@ Note that events, of type `OrdinaryRNDEvent`, are not directly constructed using
 structure. More user-friendly specification structures, such as `RNDEventSpec`, and smart constructors,
  such as `newRNDEvent` are preferably employed in practice.
  -/
-structure OrdinaryRNDEvent (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR: Refinement AM M]
+structure OrdinaryRNDEvent (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instR: Refinement AM M]
   (α β) (α':=α) (β':=β) extends _NDEvent M α β where
   po : _RNDEventPO (instR:=instR) to_NDEvent (EventKind.TransNonDet Convergence.Ordinary) α' β'
 
 @[simp]
-def OrdinaryRNDEvent.toOrdinaryNDEvent [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def OrdinaryRNDEvent.toOrdinaryNDEvent [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (ev : OrdinaryRNDEvent AM M α β α' β') : OrdinaryNDEvent M α β :=
   {
     to_NDEvent := ev.to_NDEvent
@@ -76,8 +76,8 @@ The input and output types can be lifted to the abstract, if needed,
 The proof obligations, beyond `safety` and `feasibility` (of abstract events),
 are guard `strengthening` and abstract event `simulation`.
  -/
-structure RNDEventSpec (AM) [Machine ACTX AM]
-                        (M) [Machine CTX M]
+structure RNDEventSpec (AM) [@Machine ACTX AM]
+                        (M) [@Machine CTX M]
                         [Refinement AM M]
   {α β α' β'} (abstract : OrdinaryNDEvent AM α' β')
   extends NDEventSpec M α β where
@@ -112,7 +112,7 @@ with: `abs` the (ordinary) non-deterministic event to refine, and
   `ev` the refined event specification (cf. `RNDEventSpec`).
 -/
 @[simp]
-def newRNDEvent [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newRNDEvent [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryNDEvent AM α' β') (ev : RNDEventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : OrdinaryRNDEvent AM M α β α' β' :=
   {
     to_NDEvent := ev.to_NDEvent
@@ -126,8 +126,8 @@ def newRNDEvent [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
   }
 
 /-- Variant of `RNDEventSpec` with implicit `Unit` output type -/
-structure RNDEventSpec' (AM) [Machine ACTX AM]
-                        (M) [Machine CTX M]
+structure RNDEventSpec' (AM) [@Machine ACTX AM]
+                        (M) [@Machine CTX M]
                         [Refinement AM M]
   {α α'} (abstract : OrdinaryNDEvent AM α' Unit)
   extends NDEventSpec' M α where
@@ -150,7 +150,7 @@ structure RNDEventSpec' (AM) [Machine ACTX AM]
                  ∧ refine am' m'
 
 @[simp]
-def RNDEventSpec'.toRNDEventSpec [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def RNDEventSpec'.toRNDEventSpec [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   {α α'} (abs : OrdinaryNDEvent AM α' Unit) (ev : RNDEventSpec' AM M (α:=α) (α':=α') abs) : RNDEventSpec AM M (α:=α) (β:=Unit) (α':=α') (β':=Unit) abs :=
   {
     toNDEventSpec := ev.toNDEventSpec
@@ -166,13 +166,13 @@ def RNDEventSpec'.toRNDEventSpec [Machine ACTX AM] [Machine CTX M] [Refinement A
 
 /-- Variant of `newRNDEvent` with implicit `Unit` output type -/
 @[simp]
-def newRNDEvent' [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newRNDEvent' [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryNDEvent AM α' Unit) (ev : RNDEventSpec' AM M (α:=α) (α':=α') abs) : OrdinaryRNDEvent AM M α Unit α' Unit :=
   newRNDEvent abs ev.toRNDEventSpec
 
 /-- Variant of `RNDEventSpec` with implicit `Unit` input and output types -/
-structure RNDEventSpec'' (AM) [Machine ACTX AM]
-                        (M) [Machine CTX M]
+structure RNDEventSpec'' (AM) [@Machine ACTX AM]
+                        (M) [@Machine CTX M]
                         [Refinement AM M]
   (abstract : OrdinaryNDEvent AM Unit Unit)
   extends NDEventSpec'' M where
@@ -192,7 +192,7 @@ structure RNDEventSpec'' (AM) [Machine ACTX AM]
                  ∧ refine am' m'
 
 @[simp]
-def RNDEventSpec''.toRNDEventSpec [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def RNDEventSpec''.toRNDEventSpec [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryNDEvent AM Unit Unit) (ev : RNDEventSpec'' AM M abs) : RNDEventSpec AM M (α:=Unit) (β:=Unit) (α':=Unit) (β':=Unit) abs :=
   {
     toNDEventSpec := ev.toNDEventSpec
@@ -208,7 +208,7 @@ def RNDEventSpec''.toRNDEventSpec [Machine ACTX AM] [Machine CTX M] [Refinement 
 
 /-- Variant of `newRNDEvent` with implicit `Unit` input and output types -/
 @[simp]
-def newRNDEvent'' [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newRNDEvent'' [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryNDEvent AM Unit Unit) (ev : RNDEventSpec'' AM M abs) : OrdinaryRNDEvent AM M Unit Unit :=
   newRNDEvent abs ev.toRNDEventSpec
 
@@ -217,7 +217,7 @@ def newRNDEvent'' [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
 -/
 
 /-- Internal representation of proof obligations for ordinary initialization events. -/
-structure _InitRNDEventPO  [Machine ACTX AM] [Machine CTX M] [instR: Refinement AM M]
+structure _InitRNDEventPO  [@Machine ACTX AM] [@Machine CTX M] [instR: Refinement AM M]
    (ev : _InitNDEvent M α β) (kind : EventKind) (α' β')
    extends _InitNDEventPO ev kind where
 
@@ -240,13 +240,13 @@ structure _InitRNDEventPO  [Machine ACTX AM] [Machine CTX M] [instR: Refinement 
 with: `AM` the abstact machine type, `M` the concrete maching type,
  `α` the concrete input parameter type, `α'` the corresponding abstract input type (by default, `α`)
  `β` the concrete input parameter type, `β'` the corresponding abstract input type (by default, `β`) -/
-structure InitRNDEvent (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR: Refinement AM M]
+structure InitRNDEvent (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instR: Refinement AM M]
   (α) (β) (α':=α) (β':=β)
   extends _InitNDEvent M α β where
   po : _InitRNDEventPO (instR:=instR) to_InitNDEvent (EventKind.InitNonDet) α' β'
 
 @[simp]
-def InitRNDEvent.toInitNDEvent [Machine ACTX AM] [Machine CTX M] [Refinement AM M] (ev : InitRNDEvent AM M α β α' β') : InitNDEvent M α β :=
+def InitRNDEvent.toInitNDEvent [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M] (ev : InitRNDEvent AM M α β α' β') : InitNDEvent M α β :=
 {
   to_InitNDEvent:= ev.to_InitNDEvent
   po := ev.po.to_InitNDEventPO
@@ -259,7 +259,7 @@ and abstract event `simulation`.
 The input and output types can be lifted to the abstract, if needed,
  using the `lift_in` and `lift_out` components.
  -/
-structure InitRNDEventSpec (AM) [Machine ACTX AM] (M) [Machine CTX M] [Refinement AM M]
+structure InitRNDEventSpec (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [Refinement AM M]
   {α β α' β'} (abstract : InitNDEvent AM α' β')
   extends InitNDEventSpec M α β where
 
@@ -281,7 +281,7 @@ with: `abs` the (ordinary) event to refine, and
   `ev` the refined event specification (cf. `InitRNDEventSpec`).
 -/
 @[simp]
-def newInitRNDEvent [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newInitRNDEvent [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   {α β α' β'} (abs : InitNDEvent AM α' β')
   (ev : InitRNDEventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : InitRNDEvent AM M α β α' β' :=
   {
@@ -316,7 +316,7 @@ def newInitRNDEvent [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
   }
 
 /-- Variant of `InitRNDEventSpec` with implicit `Unit` output type -/
-structure InitRNDEventSpec' (AM) [Machine ACTX AM] (M) [Machine CTX M] [Refinement AM M]
+structure InitRNDEventSpec' (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [Refinement AM M]
   {α α'} (abstract : InitNDEvent AM α' Unit)
   extends InitNDEventSpec' M α where
 
@@ -333,7 +333,7 @@ structure InitRNDEventSpec' (AM) [Machine ACTX AM] (M) [Machine CTX M] [Refineme
                ∧ refine am' m'
 
 @[simp]
-def InitRNDEventSpec'.toInitRNDEventSpec [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def InitRNDEventSpec'.toInitRNDEventSpec [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abstract : InitNDEvent AM α' Unit)
   (ev : InitRNDEventSpec' AM M (α:=α) (α':=α') abstract): InitRNDEventSpec AM M (α:=α) (β:=Unit) (α':=α') (β':=Unit) abstract :=
   {
@@ -349,13 +349,13 @@ def InitRNDEventSpec'.toInitRNDEventSpec [Machine ACTX AM] [Machine CTX M] [Refi
 
 /-- Variant of `newInitRNDEvent` with implicit `Unit` output type -/
 @[simp]
-def newInitRNDEvent' [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newInitRNDEvent' [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   {α α'} (abs : InitNDEvent AM α' Unit)
   (ev : InitRNDEventSpec' AM M (α:=α) (α':=α') abs) : InitRNDEvent AM M α Unit α' Unit :=
   newInitRNDEvent abs ev.toInitRNDEventSpec
 
 /-- Variant of `InitRNDEventSpec` with implicit `Unit` input and output types -/
-structure InitRNDEventSpec'' (AM) [Machine ACTX AM] (M) [Machine CTX M] [Refinement AM M]
+structure InitRNDEventSpec'' (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [Refinement AM M]
   (abstract : InitNDEvent AM Unit Unit)
   extends InitNDEventSpec'' M where
 
@@ -370,7 +370,7 @@ structure InitRNDEventSpec'' (AM) [Machine ACTX AM] (M) [Machine CTX M] [Refinem
                ∧ refine am' m'
 
 @[simp]
-def InitRNDEventSpec''.toInitRNDEventSpec [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def InitRNDEventSpec''.toInitRNDEventSpec [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abstract : InitNDEvent AM Unit Unit)
   (ev : InitRNDEventSpec'' AM M abstract): InitRNDEventSpec AM M (α:=Unit) (β:=Unit) (α':=Unit) (β':=Unit) abstract :=
   {
@@ -386,7 +386,7 @@ def InitRNDEventSpec''.toInitRNDEventSpec [Machine ACTX AM] [Machine CTX M] [Ref
 
 /-- Variant of `newInitRNDEvent` with implicit `Unit` input and output types -/
 @[simp]
-def newInitRNDEvent'' [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newInitRNDEvent'' [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : InitNDEvent AM Unit Unit)
   (ev : InitRNDEventSpec'' AM M abs) : InitRNDEvent AM M Unit Unit :=
   newInitRNDEvent abs ev.toInitRNDEventSpec

--- a/LeanMachines/Refinement/Relational/NonDet/Concrete.lean
+++ b/LeanMachines/Refinement/Relational/NonDet/Concrete.lean
@@ -26,7 +26,7 @@ open Refinement
 -/
 
 /-- The specification of a concrete (ordinary) non-deterministic event, refining (non-deterministic) Skip.-/
-structure ConcreteRNDEventSpec (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR: Refinement AM M] (α) (β)
+structure ConcreteRNDEventSpec (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instR: Refinement AM M] (α) (β)
   extends NDEventSpec M α β where
 
   /-- Proof obligation: the refined event safely simulates the non-deterministic Skip event
@@ -41,7 +41,7 @@ structure ConcreteRNDEventSpec (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR
 /-- The construction of a concrete (ordinary) non-deterministic event
  from a `ConcreteRNDEventSpec` specification. -/
 @[simp]
-def newConcreteRNDEvent [Machine ACTX AM] [Machine CTX M] [instR: Refinement AM M]
+def newConcreteRNDEvent [@Machine ACTX AM] [@Machine CTX M] [instR: Refinement AM M]
   (ev : ConcreteRNDEventSpec AM M α β) : OrdinaryRNDEvent AM M α β :=
   {
     to_NDEvent := ev.toNDEventSpec.to_NDEvent
@@ -57,7 +57,7 @@ def newConcreteRNDEvent [Machine ACTX AM] [Machine CTX M] [instR: Refinement AM 
   }
 
 /-- Variant of `ConcreteRNDEventSpec` with implicit `Unit` output type -/
-structure ConcreteRNDEventSpec' (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR: Refinement AM M] (α)
+structure ConcreteRNDEventSpec' (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instR: Refinement AM M] (α)
   extends NDEventSpec' M α where
 
   simulation (m : M) (x : α):
@@ -68,7 +68,7 @@ structure ConcreteRNDEventSpec' (AM) [Machine ACTX AM] (M) [Machine CTX M] [inst
                     → refine (self:=instR) am m'
 
 @[simp]
-def ConcreteRNDEventSpec'.toConcreteRNDEventSpec [Machine ACTX AM] [Machine CTX M] [instR: Refinement AM M]
+def ConcreteRNDEventSpec'.toConcreteRNDEventSpec [@Machine ACTX AM] [@Machine CTX M] [instR: Refinement AM M]
   (ev : ConcreteRNDEventSpec' AM M α) : ConcreteRNDEventSpec AM M α Unit :=
   {
     toNDEventSpec := ev.toNDEventSpec
@@ -77,12 +77,12 @@ def ConcreteRNDEventSpec'.toConcreteRNDEventSpec [Machine ACTX AM] [Machine CTX 
 
 /-- Variant of `newConcreteRNDEvent` with implicit `Unit` output type -/
 @[simp]
-def newConcreteRNDEvent' [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newConcreteRNDEvent' [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (ev : ConcreteRNDEventSpec' AM M α) : OrdinaryRNDEvent AM M α Unit :=
   newConcreteRNDEvent ev.toConcreteRNDEventSpec
 
 /-- Variant of `ConcreteRNDEventSpec` with implicit `Unit` input and output types -/
-structure ConcreteRNDEventSpec'' (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR: Refinement AM M]
+structure ConcreteRNDEventSpec'' (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instR: Refinement AM M]
   extends NDEventSpec'' M where
 
   simulation (m : M):
@@ -93,7 +93,7 @@ structure ConcreteRNDEventSpec'' (AM) [Machine ACTX AM] (M) [Machine CTX M] [ins
                     → refine (self:=instR) am m'
 
 @[simp]
-def ConcreteRNDEventSpec''.toConcreteRNDEventSpec [Machine ACTX AM] [Machine CTX M] [instR: Refinement AM M]
+def ConcreteRNDEventSpec''.toConcreteRNDEventSpec [@Machine ACTX AM] [@Machine CTX M] [instR: Refinement AM M]
   (ev : ConcreteRNDEventSpec'' AM M) : ConcreteRNDEventSpec AM M Unit Unit :=
   {
     toNDEventSpec := ev.toNDEventSpec
@@ -102,7 +102,7 @@ def ConcreteRNDEventSpec''.toConcreteRNDEventSpec [Machine ACTX AM] [Machine CTX
 
 /-- Variant of `newConcreteRNDEvent` with implicit `Unit` input and output types -/
 @[simp]
-def newConcreteNDEvent'' [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newConcreteNDEvent'' [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (ev : ConcreteRNDEventSpec'' AM M) : OrdinaryRNDEvent AM M Unit Unit :=
   newConcreteRNDEvent ev.toConcreteRNDEventSpec
 
@@ -115,7 +115,7 @@ for introducing new, concrete events in a refined machine.
 
 /-- The specification of a concrete non-deterministic anticipated event, with the requirements
 of `ConcreteRNDEventSpec` together with anticipation requirements (variant, etc).-/
-structure ConcreteAnticipatedRNDEventSpec (v) [Preorder v] [WellFoundedLT v] (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR: Refinement AM M] (α) (β)
+structure ConcreteAnticipatedRNDEventSpec (v) [Preorder v] [WellFoundedLT v] (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instR: Refinement AM M] (α) (β)
   extends _Variant v (M:=M), ConcreteRNDEventSpec AM M α β where
 
   /-- Proof obligation: the concrete variant does not increases. -/
@@ -128,7 +128,7 @@ structure ConcreteAnticipatedRNDEventSpec (v) [Preorder v] [WellFoundedLT v] (AM
 /-- The construction of a concrete non-deterministic anticipated event
 from a `ConcreteAnticipatedRNDEventSpec` specification. -/
 @[simp]
-def newConcreteAnticipatedRNDEvent [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [instR: Refinement AM M]
+def newConcreteAnticipatedRNDEvent [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [instR: Refinement AM M]
   (ev : ConcreteAnticipatedRNDEventSpec v AM M α β) : AnticipatedRNDEvent v AM M α β :=
   {
     to_NDEvent := ev.toNDEventSpec.to_NDEvent
@@ -149,7 +149,7 @@ def newConcreteAnticipatedRNDEvent [Preorder v] [WellFoundedLT v] [Machine ACTX 
   }
 
 /-- Variant of `ConcreteAnticipatedRNDEventSpec` with implicit `Unit` output type -/
-structure ConcreteAnticipatedRNDEventSpec' (v) [Preorder v] [WellFoundedLT v] (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR: Refinement AM M] (α)
+structure ConcreteAnticipatedRNDEventSpec' (v) [Preorder v] [WellFoundedLT v] (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instR: Refinement AM M] (α)
   extends _Variant v (M:=M), ConcreteRNDEventSpec' AM M α where
 
   nonIncreasing (m : M) (x : α):
@@ -159,7 +159,7 @@ structure ConcreteAnticipatedRNDEventSpec' (v) [Preorder v] [WellFoundedLT v] (A
             → variant m' ≤ variant m
 
 @[simp]
-def ConcreteAnticipatedRNDEventSpec'.toConcreteAnticipatedRNDEventSpec [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [instR: Refinement AM M]
+def ConcreteAnticipatedRNDEventSpec'.toConcreteAnticipatedRNDEventSpec [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [instR: Refinement AM M]
   (ev : ConcreteAnticipatedRNDEventSpec' v AM M α) : ConcreteAnticipatedRNDEventSpec v AM M α Unit :=
   {
     toNDEventSpec := ev.toNDEventSpec
@@ -170,12 +170,12 @@ def ConcreteAnticipatedRNDEventSpec'.toConcreteAnticipatedRNDEventSpec [Preorder
 
 /-- Variant of `newConcreteAnticipatedRNDEvent` with implicit `Unit` output type -/
 @[simp]
-def newConcreteAnticipatedRNDEvent' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newConcreteAnticipatedRNDEvent' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (ev : ConcreteAnticipatedRNDEventSpec' v AM M α) : AnticipatedRNDEvent v AM M α Unit :=
   newConcreteAnticipatedRNDEvent ev.toConcreteAnticipatedRNDEventSpec
 
 /-- Variant of `ConcreteAnticipatedRNDEventSpec` with implicit `Unit` input and output types -/
-structure ConcreteAnticipatedRNDEventSpec'' (v) [Preorder v] [WellFoundedLT v] (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR: Refinement AM M]
+structure ConcreteAnticipatedRNDEventSpec'' (v) [Preorder v] [WellFoundedLT v] (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instR: Refinement AM M]
   extends _Variant v (M:=M), ConcreteRNDEventSpec'' AM M where
 
   nonIncreasing (m : M):
@@ -185,7 +185,7 @@ structure ConcreteAnticipatedRNDEventSpec'' (v) [Preorder v] [WellFoundedLT v] (
             → variant m' ≤ variant m
 
 @[simp]
-def ConcreteAnticipatedRNDEventSpec''.toConcreteAnticipatedRNDEventSpec [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [instR: Refinement AM M]
+def ConcreteAnticipatedRNDEventSpec''.toConcreteAnticipatedRNDEventSpec [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [instR: Refinement AM M]
   (ev : ConcreteAnticipatedRNDEventSpec'' v AM M) : ConcreteAnticipatedRNDEventSpec v AM M Unit Unit :=
   {
     toNDEventSpec := ev.toNDEventSpec
@@ -196,7 +196,7 @@ def ConcreteAnticipatedRNDEventSpec''.toConcreteAnticipatedRNDEventSpec [Preorde
 
 /-- Variant of `newConcreteAnticipatedRNDEvent` with implicit `Unit` input and output types -/
 @[simp]
-def newConcreteAnticipatedNDEvent'' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newConcreteAnticipatedNDEvent'' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (ev : ConcreteAnticipatedRNDEventSpec'' v AM M) : AnticipatedRNDEvent v AM M Unit Unit :=
   newConcreteAnticipatedRNDEvent ev.toConcreteAnticipatedRNDEventSpec
 
@@ -206,7 +206,7 @@ def newConcreteAnticipatedNDEvent'' [Preorder v] [WellFoundedLT v] [Machine ACTX
 
 /-- The specification of a concrete non-deterministic convergent event, with the requirements
 of `ConcreteRNDEventSpec` together with convergence requirements (variant, etc).-/
-structure ConcreteConvergentRNDEventSpec (v) [Preorder v] [WellFoundedLT v] (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR: Refinement AM M] (α) (β)
+structure ConcreteConvergentRNDEventSpec (v) [Preorder v] [WellFoundedLT v] (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instR: Refinement AM M] (α) (β)
   extends _Variant v (M:=M), ConcreteRNDEventSpec AM M α β where
 
   /-- Proof obligation: the variant strictly decrases. -/
@@ -219,7 +219,7 @@ structure ConcreteConvergentRNDEventSpec (v) [Preorder v] [WellFoundedLT v] (AM)
 /-- The construction of a concrete non-deterministic convergent event
 from a `ConcreteConvergentRNDEventSpec` specification. -/
 @[simp]
-def newConcreteConvergentRNDEvent [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [instR: Refinement AM M]
+def newConcreteConvergentRNDEvent [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [instR: Refinement AM M]
   (ev : ConcreteConvergentRNDEventSpec v AM M α β) : ConvergentRNDEvent v AM M α β :=
   {
     to_NDEvent := ev.toNDEventSpec.to_NDEvent
@@ -241,7 +241,7 @@ def newConcreteConvergentRNDEvent [Preorder v] [WellFoundedLT v] [Machine ACTX A
   }
 
 /-- Variant of `ConcreteConvergentRNDEventSpec` with implicit `Unit` output type -/
-structure ConcreteConvergentRNDEventSpec' (v) [Preorder v] [WellFoundedLT v] (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR: Refinement AM M] (α)
+structure ConcreteConvergentRNDEventSpec' (v) [Preorder v] [WellFoundedLT v] (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instR: Refinement AM M] (α)
   extends _Variant v (M:=M), ConcreteRNDEventSpec' AM M α where
 
   convergence (m : M) (x : α):
@@ -251,7 +251,7 @@ structure ConcreteConvergentRNDEventSpec' (v) [Preorder v] [WellFoundedLT v] (AM
             → variant m' < variant m
 
 @[simp]
-def ConcreteConvergentRNDEventSpec'.toConcreteConvergentRNDEventSpec [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [instR: Refinement AM M]
+def ConcreteConvergentRNDEventSpec'.toConcreteConvergentRNDEventSpec [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [instR: Refinement AM M]
   (ev : ConcreteConvergentRNDEventSpec' v AM M α) : ConcreteConvergentRNDEventSpec v AM M α Unit :=
   {
     toNDEventSpec := ev.toNDEventSpec
@@ -262,12 +262,12 @@ def ConcreteConvergentRNDEventSpec'.toConcreteConvergentRNDEventSpec [Preorder v
 
 /-- Variant of `newConcreteConvergentRNDEvent` with implicit `Unit` output type -/
 @[simp]
-def newConcreteConvergentRNDEvent' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newConcreteConvergentRNDEvent' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (ev : ConcreteConvergentRNDEventSpec' v AM M α) : ConvergentRNDEvent v AM M α Unit :=
   newConcreteConvergentRNDEvent ev.toConcreteConvergentRNDEventSpec
 
 /-- Variant of `ConcreteConvergentRNDEventSpec` with implicit `Unit` input and output types -/
-structure ConcreteConvergentRNDEventSpec'' (v) [Preorder v] [WellFoundedLT v] (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR: Refinement AM M]
+structure ConcreteConvergentRNDEventSpec'' (v) [Preorder v] [WellFoundedLT v] (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instR: Refinement AM M]
   extends _Variant v (M:=M), ConcreteRNDEventSpec'' AM M where
 
   convergence (m : M):
@@ -277,7 +277,7 @@ structure ConcreteConvergentRNDEventSpec'' (v) [Preorder v] [WellFoundedLT v] (A
             → variant m' < variant m
 
 @[simp]
-def ConcreteConvergentRNDEventSpec''.toConcreteConvergentRNDEventSpec [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [instR: Refinement AM M]
+def ConcreteConvergentRNDEventSpec''.toConcreteConvergentRNDEventSpec [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [instR: Refinement AM M]
   (ev : ConcreteConvergentRNDEventSpec'' v AM M) : ConcreteConvergentRNDEventSpec v AM M Unit Unit :=
   {
     toNDEventSpec := ev.toNDEventSpec
@@ -288,6 +288,6 @@ def ConcreteConvergentRNDEventSpec''.toConcreteConvergentRNDEventSpec [Preorder 
 
 /-- Variant of `newConcreteConvergentRNDEvent` with implicit `Unit` input and output types -/
 @[simp]
-def newConcreteConvergentNDEvent'' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newConcreteConvergentNDEvent'' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (ev : ConcreteConvergentRNDEventSpec'' v AM M) : ConvergentRNDEvent v AM M Unit Unit :=
   newConcreteConvergentRNDEvent ev.toConcreteConvergentRNDEventSpec

--- a/LeanMachines/Refinement/Relational/NonDet/Convergent.lean
+++ b/LeanMachines/Refinement/Relational/NonDet/Convergent.lean
@@ -19,7 +19,7 @@ open Refinement
 -/
 
 /-- Internal representation of proof obligations for anticipated events -/
-structure _AnticipatedRNDEventPO (v) [Preorder v]  [Machine ACTX AM] [instM:Machine CTX M] [instR: Refinement AM M]
+structure _AnticipatedRNDEventPO (v) [Preorder v]  [@Machine ACTX AM] [instM:@Machine CTX M] [instR: Refinement AM M]
   (ev : _NDEvent M α β) (kind : EventKind) (α') (β')
           extends _Variant v (instM:=instM), _RNDEventPO (instR:=instR) ev kind α' β'  where
 
@@ -32,13 +32,13 @@ structure _AnticipatedRNDEventPO (v) [Preorder v]  [Machine ACTX AM] [instM:Mach
 /-- The representation of anticipated non-deterministic refined events, constructed
 by specifications structures, e.g. `AnticipatedRNDEventSpec`,
  and smart constructors, e.g. `newAnticipatedRNDEvent`. -/
-structure AnticipatedRNDEvent (v) [Preorder v] (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR: Refinement AM M]
+structure AnticipatedRNDEvent (v) [Preorder v] (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instR: Refinement AM M]
   (α β) (α':=α) (β':=β)
   extends _NDEvent M α β where
   po : _AnticipatedRNDEventPO v (instR:=instR) to_NDEvent (EventKind.TransDet Convergence.Anticipated) α' β'
 
 @[simp]
-def AnticipatedRNDEvent.toAnticipatedNDEvent [Preorder v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def AnticipatedRNDEvent.toAnticipatedNDEvent [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (ev : AnticipatedRNDEvent v AM M α β α' β') : AnticipatedNDEvent v M α β :=
   { to_NDEvent := ev.to_NDEvent
     po := {
@@ -65,7 +65,7 @@ The input and output types can be lifted to the abstract, if needed,
 The added proof obligation, beyond `safety` , guard `strengthening`,
 abstract event `simulation`, is a `nonIncreasing` requirement.
  -/
-structure AnticipatedRNDEventSpec (v) [Preorder v] (AM) [Machine ACTX AM] (M) [instM:Machine CTX M] [Refinement AM M]
+structure AnticipatedRNDEventSpec (v) [Preorder v] (AM) [@Machine ACTX AM] (M) [instM:@Machine CTX M] [Refinement AM M]
   {α β α' β'} (abs : OrdinaryNDEvent AM α' β')
   extends _Variant v (instM:=instM), RNDEventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abs where
 
@@ -77,7 +77,7 @@ structure AnticipatedRNDEventSpec (v) [Preorder v] (AM) [Machine ACTX AM] (M) [i
                  → variant m' ≤ variant m
 
 @[simp]
-private def _newAnticipatedRNDEvent [Preorder v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+private def _newAnticipatedRNDEvent [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryNDEvent AM α' β') (ev : AnticipatedRNDEventSpec v AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : AnticipatedRNDEvent v AM M α β α' β' :=
   {
     to_NDEvent := ev.to_NDEvent
@@ -100,18 +100,18 @@ with: `abs` the ordinary event to refine, and
   (cf. `AnticipatedRNDEventSpec`).
 -/
 @[simp]
-def newAnticipatedRNDEventfromOrdinary [Preorder v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newAnticipatedRNDEventfromOrdinary [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryNDEvent AM α' β') (ev : AnticipatedRNDEventSpec v AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : AnticipatedRNDEvent v AM M α β α' β' :=
   _newAnticipatedRNDEvent abs ev
 
 /-- Variant of `newAnticipatedRNDEventfromOrdinary` for anticipated events. -/
 @[simp]
-def newAnticipatedRNDEventfromAnticipated [Preorder v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newAnticipatedRNDEventfromAnticipated [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : AnticipatedNDEvent v AM α' β') (ev : AnticipatedRNDEventSpec v AM M (α:=α) (β:=β) (α':=α') (β':=β') abs.toOrdinaryNDEvent) : AnticipatedRNDEvent v AM M α β α' β' :=
   _newAnticipatedRNDEvent abs.toOrdinaryNDEvent ev
 
 /-- Variant of `AnticipatedRNDEventSpec` with implicit `Unit` output type -/
-structure AnticipatedRNDEventSpec' (v) [Preorder v] (AM) [Machine ACTX AM] (M) [instM:Machine CTX M] [Refinement AM M]
+structure AnticipatedRNDEventSpec' (v) [Preorder v] (AM) [@Machine ACTX AM] (M) [instM:@Machine CTX M] [Refinement AM M]
   {α α'} (abs : OrdinaryNDEvent AM α' Unit)
   extends _Variant v (instM:=instM), RNDEventSpec' AM M (α:=α) (α':=α') abs where
 
@@ -122,7 +122,7 @@ structure AnticipatedRNDEventSpec' (v) [Preorder v] (AM) [Machine ACTX AM] (M) [
             → variant m' ≤ variant m
 
 @[simp]
-def AnticipatedRNDEventSpec'.toAnticipatedRNDEventSpec [Preorder v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def AnticipatedRNDEventSpec'.toAnticipatedRNDEventSpec [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryNDEvent AM α' Unit)
   (ev : AnticipatedRNDEventSpec' v AM M (α:=α) (α':=α') abs): AnticipatedRNDEventSpec v AM M (α:=α) (β:=Unit) (α':=α') (β':=Unit) abs :=
   {
@@ -133,18 +133,18 @@ def AnticipatedRNDEventSpec'.toAnticipatedRNDEventSpec [Preorder v] [Machine ACT
 
 /-- Variant of `newAnticipatedRNDEventFromOrdinary` with implicit `Unit` output type -/
 @[simp]
-def newAnticipatedRNDEventfromOrdinary' [Preorder v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newAnticipatedRNDEventfromOrdinary' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryNDEvent AM α' Unit) (ev : AnticipatedRNDEventSpec' v AM M (α:=α) (α':=α') abs) : AnticipatedRNDEvent v AM M α Unit α' Unit :=
   _newAnticipatedRNDEvent abs ev.toAnticipatedRNDEventSpec
 
 /-- Variant of `newAnticipatedRNDEventFromAnticipated` with implicit `Unit` output type -/
 @[simp]
-def newAnticipatedRNDEventfromAnticipated' [Preorder v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newAnticipatedRNDEventfromAnticipated' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : AnticipatedNDEvent v AM α' Unit) (ev : AnticipatedRNDEventSpec' v AM M (α:=α) (α':=α') abs.toOrdinaryNDEvent) : AnticipatedRNDEvent v AM M α Unit α' Unit :=
   _newAnticipatedRNDEvent abs.toOrdinaryNDEvent ev.toAnticipatedRNDEventSpec
 
 /-- Variant of `AnticipatedRNDEventSpec` with implicit `Unit` input and output types -/
-structure AnticipatedRNDEventSpec'' (v) [Preorder v] (AM) [Machine ACTX AM] (M) [instM:Machine CTX M] [Refinement AM M]
+structure AnticipatedRNDEventSpec'' (v) [Preorder v] (AM) [@Machine ACTX AM] (M) [instM:@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryNDEvent AM Unit Unit)
   extends _Variant v (instM:=instM), RNDEventSpec'' AM M abs where
 
@@ -155,7 +155,7 @@ structure AnticipatedRNDEventSpec'' (v) [Preorder v] (AM) [Machine ACTX AM] (M) 
             → variant m' ≤ variant m
 
 @[simp]
-def AnticipatedRNDEventSpec''.toAnticipatedRNDEventSpec [Preorder v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def AnticipatedRNDEventSpec''.toAnticipatedRNDEventSpec [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryNDEvent AM Unit Unit)
   (ev : AnticipatedRNDEventSpec'' v AM M abs): AnticipatedRNDEventSpec v AM M (α:=Unit) (β:=Unit) (α':=Unit) (β':=Unit) abs :=
   {
@@ -166,13 +166,13 @@ def AnticipatedRNDEventSpec''.toAnticipatedRNDEventSpec [Preorder v] [Machine AC
 
 /-- Variant of `newAnticipatedRNDEventfromOrdinary` with implicit `Unit` input and output types -/
 @[simp]
-def newAnticipatedRNDEventfromOrdinary'' [Preorder v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newAnticipatedRNDEventfromOrdinary'' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryNDEvent AM Unit Unit) (ev : AnticipatedRNDEventSpec'' v AM M abs) : AnticipatedRNDEvent v AM M Unit Unit :=
   _newAnticipatedRNDEvent abs ev.toAnticipatedRNDEventSpec
 
 /-- Variant of `newAnticipatedRNDEventfromAnticipated` with implicit `Unit` input and output types -/
 @[simp]
-def newAnticipatedRNDEventfromAnticipated'' [Preorder v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newAnticipatedRNDEventfromAnticipated'' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : AnticipatedNDEvent v AM Unit Unit) (ev : AnticipatedRNDEventSpec'' v AM M abs.toOrdinaryNDEvent) : AnticipatedRNDEvent v AM M Unit Unit :=
   _newAnticipatedRNDEvent abs.toOrdinaryNDEvent ev.toAnticipatedRNDEventSpec
 
@@ -181,7 +181,7 @@ def newAnticipatedRNDEventfromAnticipated'' [Preorder v] [Machine ACTX AM] [Mach
 -/
 
 /-- Internal representation of proof obligations for convergent refined non-deterministic events -/
-structure _ConvergentRNDEventPO (v) [Preorder v] [WellFoundedLT v]  [Machine ACTX AM] [instM:Machine CTX M] [instR: Refinement AM M]
+structure _ConvergentRNDEventPO (v) [Preorder v] [WellFoundedLT v]  [@Machine ACTX AM] [instM:@Machine CTX M] [instR: Refinement AM M]
   (ev : _NDEvent M α β) (kind : EventKind) (α') (β')
           extends _Variant v (instM:=instM), _AnticipatedRNDEventPO (instR:=instR) v ev kind α' β' where
 
@@ -194,13 +194,13 @@ structure _ConvergentRNDEventPO (v) [Preorder v] [WellFoundedLT v]  [Machine ACT
 /-- The representation of convergent non-deterministic refined events, constructed
 by specifications structures, e.g. `ConvergentRNDEventSpec`,
  and smart constructors, e.g. `newConvergentRNDEvent`. -/
-structure ConvergentRNDEvent (v) [Preorder v] [WellFoundedLT v] (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR: Refinement AM M]
+structure ConvergentRNDEvent (v) [Preorder v] [WellFoundedLT v] (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instR: Refinement AM M]
   (α β) (α':=α) (β':=β)
   extends _NDEvent M α β where
   po : _ConvergentRNDEventPO v (instR:=instR) to_NDEvent (EventKind.TransDet Convergence.Anticipated) α' β'
 
 @[simp]
-def ConvergentRNDEvent.toConvergentNDEvent [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [instR: Refinement AM M]
+def ConvergentRNDEvent.toConvergentNDEvent [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [instR: Refinement AM M]
   (ev : ConvergentRNDEvent v AM M α β α' β') : ConvergentNDEvent v M α β :=
   { to_NDEvent := ev.to_NDEvent
     po := {
@@ -229,7 +229,7 @@ The input and output types can be lifted to the abstract, if needed,
 The added proof obligation, beyond `safety` , guard `strengthening`,
 abstract event `simulation`, is a `convergence` requirement.
  -/
-structure ConvergentRNDEventSpec (v) [Preorder v] [WellFoundedLT v] (AM) [Machine ACTX AM] (M) [instM:Machine CTX M] [Refinement AM M]
+structure ConvergentRNDEventSpec (v) [Preorder v] [WellFoundedLT v] (AM) [@Machine ACTX AM] (M) [instM:@Machine CTX M] [Refinement AM M]
   {α β α' β'} (abs : OrdinaryNDEvent AM α' β')
   extends _Variant v (instM:=instM), RNDEventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abs where
 
@@ -245,7 +245,7 @@ with: `abs` the event to refine, and
   `ev` the refined event specification (cf. `ConvergentRNDEventSpec`).
 -/
 @[simp]
-def newConvergentRNDEvent [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newConvergentRNDEvent [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryNDEvent AM α' β') (ev : ConvergentRNDEventSpec v AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : ConvergentRNDEvent v AM M α β α' β' :=
   {
     to_NDEvent := ev.to_NDEvent
@@ -266,7 +266,7 @@ def newConvergentRNDEvent [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Mach
   }
 
 /-- Variant of `ConvergentRNDEventSpec` with implicit `Unit` output type -/
-structure ConvergentRNDEventSpec' (v) [Preorder v] [WellFoundedLT v] (AM) [Machine ACTX AM] (M) [instM:Machine CTX M] [Refinement AM M]
+structure ConvergentRNDEventSpec' (v) [Preorder v] [WellFoundedLT v] (AM) [@Machine ACTX AM] (M) [instM:@Machine CTX M] [Refinement AM M]
   {α α'} (abs : OrdinaryNDEvent AM α' Unit)
   extends _Variant v (instM:=instM), RNDEventSpec' AM M (α:=α) (α':=α') abs where
 
@@ -277,7 +277,7 @@ structure ConvergentRNDEventSpec' (v) [Preorder v] [WellFoundedLT v] (AM) [Machi
             → variant m' < variant m
 
 @[simp]
-def ConvergentRNDEventSpec'.toConvergentRNDEventSpec [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def ConvergentRNDEventSpec'.toConvergentRNDEventSpec [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryNDEvent AM α' Unit)
   (ev : ConvergentRNDEventSpec' v AM M (α:=α) (α':=α') abs): ConvergentRNDEventSpec v AM M (α:=α) (β:=Unit) (α':=α') (β':=Unit) abs :=
   {
@@ -288,12 +288,12 @@ def ConvergentRNDEventSpec'.toConvergentRNDEventSpec [Preorder v] [WellFoundedLT
 
 /-- Variant of `newConvergentRNDEvent` with implicit `Unit` output type -/
 @[simp]
-def newConvergentRNDEvent' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newConvergentRNDEvent' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryNDEvent AM α' Unit) (ev : ConvergentRNDEventSpec' v AM M (α:=α) (α':=α') abs) : ConvergentRNDEvent v AM M α Unit α' Unit :=
   newConvergentRNDEvent abs ev.toConvergentRNDEventSpec
 
 /-- Variant of `ConvergentRNDEventSpec` with implicit `Unit` input and output types -/
-structure ConvergentRNDEventSpec'' (v) [Preorder v] [WellFoundedLT v] (AM) [Machine ACTX AM] (M) [instM:Machine CTX M] [Refinement AM M]
+structure ConvergentRNDEventSpec'' (v) [Preorder v] [WellFoundedLT v] (AM) [@Machine ACTX AM] (M) [instM:@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryNDEvent AM Unit Unit)
   extends _Variant v (instM:=instM), RNDEventSpec'' AM M abs where
 
@@ -304,7 +304,7 @@ structure ConvergentRNDEventSpec'' (v) [Preorder v] [WellFoundedLT v] (AM) [Mach
             → variant m' < variant m
 
 @[simp]
-def ConvergentRNDEventSpec''.toConvergentRNDEventSpec [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def ConvergentRNDEventSpec''.toConvergentRNDEventSpec [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryNDEvent AM Unit Unit)
   (ev : ConvergentRNDEventSpec'' v AM M abs): ConvergentRNDEventSpec v AM M (α:=Unit) (β:=Unit) (α':=Unit) (β':=Unit) abs :=
   {
@@ -315,6 +315,6 @@ def ConvergentRNDEventSpec''.toConvergentRNDEventSpec [Preorder v] [WellFoundedL
 
 /-- Variant of `newConvergentRNDEvent` with implicit `Unit` input and output types -/
 @[simp]
-def newConvergentRNDEvent'' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newConvergentRNDEvent'' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryNDEvent AM Unit Unit) (ev : ConvergentRNDEventSpec'' v AM M abs) : ConvergentRNDEvent v AM M Unit Unit :=
   newConvergentRNDEvent abs ev.toConvergentRNDEventSpec

--- a/LeanMachines/Refinement/Relational/NonDet/Det/Basic.lean
+++ b/LeanMachines/Refinement/Relational/NonDet/Det/Basic.lean
@@ -15,7 +15,7 @@ refine non-determistic abstract events.
 
 /-- The internal representation of the proof obligations for deterministic
 refined events. -/
-structure _RDetEventPO  [Machine ACTX AM] [Machine CTX M] [instR: Refinement AM M]
+structure _RDetEventPO  [@Machine ACTX AM] [@Machine CTX M] [instR: Refinement AM M]
    (ev : _Event M α β) (kind : EventKind) (α' β')
    extends _EventPO ev kind where
 
@@ -47,12 +47,12 @@ Note that events, of type `OrdinaryRDetEvent`, are not directly constructed usin
 structure. More user-friendly specification structures, such as `RDetEventSpec`, and smart constructors,
  such as `newRDetEvent` are preferably employed in practice.
  -/
-structure OrdinaryRDetEvent (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR: Refinement AM M]
+structure OrdinaryRDetEvent (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instR: Refinement AM M]
   (α) (β) (α':=α) (β':=β) extends _Event M α β where
   po : _RDetEventPO (instR:=instR) to_Event (EventKind.TransDet Convergence.Ordinary) α' β'
 
 @[simp]
-def OrdinaryRDetEvent.toOrdinaryEvent [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def OrdinaryRDetEvent.toOrdinaryEvent [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (ev : OrdinaryRDetEvent AM M α β) : OrdinaryEvent M α β :=
   {
     to_Event := ev.to_Event
@@ -73,7 +73,7 @@ The input and output types can be lifted to the abstract, if needed,
 The proof obligations, beyond `safety` are guard `strengthening`
 and abstract event `simulation`,  cf. `REventSpec`.
  -/
-structure RDetEventSpec (AM) [Machine ACTX AM] (M) [Machine CTX M] [Refinement AM M]
+structure RDetEventSpec (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [Refinement AM M]
   {α β α' β'} (abstract : OrdinaryNDEvent AM α' β')
   extends EventSpec M α β where
 
@@ -99,7 +99,7 @@ with: `abs` the (ordinary) non-deterministic event to refine, and
   `ev` the refined event specification (cf. `RDetEventSpec`).
 -/
 @[simp]
-def newRDetEvent [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newRDetEvent [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryNDEvent AM α' β') (ev : RDetEventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : OrdinaryRDetEvent AM M α β α' β' :=
   {
     to_Event := ev.to_Event
@@ -112,7 +112,7 @@ def newRDetEvent [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
   }
 
 /-- Variant of `RDetEventSpec` with implicit `Unit` output type -/
-structure RDetEventSpec' (AM) [Machine ACTX AM] (M) [Machine CTX M] [Refinement AM M]
+structure RDetEventSpec' (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [Refinement AM M]
   {α α'} (abstract : OrdinaryNDEvent AM α' Unit)
   extends EventSpec' M α where
 
@@ -133,7 +133,7 @@ structure RDetEventSpec' (AM) [Machine ACTX AM] (M) [Machine CTX M] [Refinement 
                ∧ refine am' m'
 
 @[simp]
-def RDetEventSpec'.toRDetEventSpec [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def RDetEventSpec'.toRDetEventSpec [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abstract : OrdinaryNDEvent AM α' Unit)
   (ev : RDetEventSpec' AM M (α:=α) (α':=α') abstract) : RDetEventSpec AM M (α:=α) (β:=Unit) (α':=α') (β':=Unit) abstract :=
   {
@@ -146,12 +146,12 @@ def RDetEventSpec'.toRDetEventSpec [Machine ACTX AM] [Machine CTX M] [Refinement
 
 /-- Variant of `newRDetEvent` with implicit `Unit` output type -/
 @[simp]
-def newRDetEvent' [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newRDetEvent' [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryNDEvent AM α' Unit) (ev : RDetEventSpec' AM M (α:=α) (α':=α') abs) : OrdinaryRDetEvent AM M α Unit α' Unit :=
   newRDetEvent abs ev.toRDetEventSpec
 
 /-- Variant of `RDetEventSpec` with implicit `Unit` input and output types -/
-structure RDetEventSpec'' (AM) [Machine ACTX AM] (M) [Machine CTX M] [Refinement AM M]
+structure RDetEventSpec'' (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [Refinement AM M]
   (abstract : OrdinaryNDEvent AM Unit Unit)
   extends EventSpec'' M where
 
@@ -170,7 +170,7 @@ structure RDetEventSpec'' (AM) [Machine ACTX AM] (M) [Machine CTX M] [Refinement
                ∧ refine am' m'
 
 @[simp]
-def RDetEventSpec''.toRDetEventSpec [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def RDetEventSpec''.toRDetEventSpec [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abstract : OrdinaryNDEvent AM Unit Unit)
   (ev : RDetEventSpec'' AM M abstract) : RDetEventSpec AM M (α:=Unit) (β:=Unit) (α':=Unit) (β':=Unit) abstract :=
   {
@@ -183,7 +183,7 @@ def RDetEventSpec''.toRDetEventSpec [Machine ACTX AM] [Machine CTX M] [Refinemen
 
 /-- Variant of `newRDetEvent` with implicit `Unit` input and output types -/
 @[simp]
-def newRDetEvent'' [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newRDetEvent'' [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryNDEvent AM Unit Unit) (ev : RDetEventSpec'' AM M abs) : OrdinaryRDetEvent AM M Unit Unit :=
   newRDetEvent abs ev.toRDetEventSpec
 
@@ -193,7 +193,7 @@ def newRDetEvent'' [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
 
 /-- Internal representation of proof obligations for ordinary deterministic
 initialization events. -/
-structure _InitRDetEventPO  [Machine ACTX AM] [Machine CTX M] [instR: Refinement AM M]
+structure _InitRDetEventPO  [@Machine ACTX AM] [@Machine CTX M] [instR: Refinement AM M]
    (ev : _InitEvent M α β) (kind : EventKind) (α' β')
    extends _InitEventPO ev kind where
 
@@ -216,12 +216,12 @@ structure _InitRDetEventPO  [Machine ACTX AM] [Machine CTX M] [instR: Refinement
 with: `AM` the abstact machine type, `M` the concrete maching type,
  `α` the concrete input parameter type, `α'` the corresponding abstract input type (by default, `α`)
  `β` the concrete input parameter type, `β'` the corresponding abstract input type (by default, `β`) -/
-structure InitRDetEvent (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR: Refinement AM M]
+structure InitRDetEvent (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instR: Refinement AM M]
   (α) (β) (α':=α) (β':=β) extends _InitEvent M α β where
   po : _InitRDetEventPO (instR:=instR) to_InitEvent EventKind.InitDet α' β'
 
 @[simp]
-def InitRDetEvent.toInitEvent [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def InitRDetEvent.toInitEvent [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (ev : InitRDetEvent AM M α β) : InitEvent M α β :=
   {
     to_InitEvent := ev.to_InitEvent
@@ -235,7 +235,7 @@ and abstract event `simulation`.
 The input and output types can be lifted to the abstract, if needed,
  using the `lift_in` and `lift_out` components.
  -/
-structure InitRDetEventSpec (AM) [Machine ACTX AM] (M) [Machine CTX M] [Refinement AM M]
+structure InitRDetEventSpec (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [Refinement AM M]
   {α β α' β'} (abstract : InitNDEvent AM α' β')
   extends InitEventSpec M α β where
 
@@ -257,7 +257,7 @@ with: `abs` the (ordinary) non-deterministic event to refine, and
   `ev` the refined event specification (cf. `InitREventSpec`).
 -/
 @[simp]
-def newInitRDetEvent [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newInitRDetEvent [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : InitNDEvent AM α' β') (ev : InitRDetEventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : InitRDetEvent AM M α β α' β' :=
   {
     to_InitEvent := ev.to_InitEvent
@@ -282,7 +282,7 @@ def newInitRDetEvent [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
   }
 
 /-- Variant of `InitRDetEventSpec` with implicit `Unit` output type -/
-structure InitRDetEventSpec' (AM) [Machine ACTX AM] (M) [Machine CTX M] [Refinement AM M]
+structure InitRDetEventSpec' (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [Refinement AM M]
   {α α'} (abstract : InitNDEvent AM α' Unit)
   extends InitEventSpec' M α where
 
@@ -299,7 +299,7 @@ structure InitRDetEventSpec' (AM) [Machine ACTX AM] (M) [Machine CTX M] [Refinem
               ∧ refine am' m'
 
 @[simp]
-def InitRDetEventSpec'.toInitRDetEventSpec [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def InitRDetEventSpec'.toInitRDetEventSpec [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abstract : InitNDEvent AM α' Unit)
   (ev : InitRDetEventSpec' AM M (α:=α) (α':=α') abstract) : InitRDetEventSpec AM M (α:=α) (β:=Unit) (α':=α') (β':=Unit) abstract :=
   {
@@ -312,12 +312,12 @@ def InitRDetEventSpec'.toInitRDetEventSpec [Machine ACTX AM] [Machine CTX M] [Re
 
 /-- Variant of `newInitRDetEvent` with implicit `Unit` output type -/
 @[simp]
-def newInitRDetEvent' [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newInitRDetEvent' [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : InitNDEvent AM α' Unit) (ev : InitRDetEventSpec' AM M (α:=α) (α':=α') abs) : InitRDetEvent AM M α Unit α' Unit :=
   newInitRDetEvent abs ev.toInitRDetEventSpec
 
 /-- Variant of `InitRDetEventSpec` with implicit `Unit` input and output types -/
-structure InitRDetEventSpec'' (AM) [Machine ACTX AM] (M) [Machine CTX M] [Refinement AM M]
+structure InitRDetEventSpec'' (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [Refinement AM M]
   (abstract : InitNDEvent AM Unit Unit)
   extends InitEventSpec'' M where
 
@@ -332,7 +332,7 @@ structure InitRDetEventSpec'' (AM) [Machine ACTX AM] (M) [Machine CTX M] [Refine
               ∧ refine am' m'
 
 @[simp]
-def InitRDetEventSpec''.toInitRDetEventSpec [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def InitRDetEventSpec''.toInitRDetEventSpec [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abstract : InitNDEvent AM Unit Unit)
   (ev : InitRDetEventSpec'' AM M abstract) : InitRDetEventSpec AM M (α:=Unit) (β:=Unit) (α':=Unit) (β':=Unit) abstract :=
   {
@@ -345,6 +345,6 @@ def InitRDetEventSpec''.toInitRDetEventSpec [Machine ACTX AM] [Machine CTX M] [R
 
 /-- Variant of `newRDetEvent` with implicit `Unit` input and output types -/
 @[simp]
-def newInitRDetEvent'' [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newInitRDetEvent'' [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : InitNDEvent AM Unit Unit) (ev : InitRDetEventSpec'' AM M abs) : InitRDetEvent AM M Unit Unit :=
   newInitRDetEvent abs ev.toInitRDetEventSpec

--- a/LeanMachines/Refinement/Relational/NonDet/Det/Convergent.lean
+++ b/LeanMachines/Refinement/Relational/NonDet/Det/Convergent.lean
@@ -21,7 +21,7 @@ open Refinement
 -/
 
 /-- Internal representation of proof obligations for anticipated events -/
-structure _AnticipatedRDetEventPO (v) [Preorder v]  [Machine ACTX AM] [instM:Machine CTX M] [instR: Refinement AM M]
+structure _AnticipatedRDetEventPO (v) [Preorder v]  [@Machine ACTX AM] [instM:@Machine CTX M] [instR: Refinement AM M]
           (ev : _Event M α β) (kind : EventKind) (α' β')
           extends _Variant v (instM:=instM), _RDetEventPO (instR:=instR) ev kind α' β'  where
 
@@ -34,7 +34,7 @@ structure _AnticipatedRDetEventPO (v) [Preorder v]  [Machine ACTX AM] [instM:Mac
 /-- The representation of anticipated deterministic refined events, constructed
 by specifications structures, e.g. `AnticipatedRDetEventSpec`,
  and smart constructors, e.g. `newAnticipatedRDetEvent`. -/
-structure AnticipatedRDetEvent (v) [Preorder v] (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR: Refinement AM M]
+structure AnticipatedRDetEvent (v) [Preorder v] (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instR: Refinement AM M]
   (α) (β) (α':=α) (β':=β) extends _Event M α β where
   po : _AnticipatedRDetEventPO v (instR:=instR) to_Event (EventKind.TransDet Convergence.Anticipated) α' β'
 
@@ -54,7 +54,7 @@ The input and output types can be lifted to the abstract, if needed,
 The added proof obligation, beyond `safety` , guard `strengthening`,
 abstract event `simulation`, is a `nonIncreasing` requirement.
  -/
-structure AnticipatedRDetEventSpec (v) [Preorder v] (AM) [Machine ACTX AM] (M) [instM:Machine CTX M] [Refinement AM M]
+structure AnticipatedRDetEventSpec (v) [Preorder v] (AM) [@Machine ACTX AM] (M) [instM:@Machine CTX M] [Refinement AM M]
   {α β α' β'} (abstract : OrdinaryNDEvent AM α' β')
   extends _Variant v (instM:=instM), RDetEventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abstract where
 
@@ -65,7 +65,7 @@ structure AnticipatedRDetEventSpec (v) [Preorder v] (AM) [Machine ACTX AM] (M) [
       variant m' ≤ variant m
 
 @[simp]
-private def _newAnticipatedRDetEvent [Preorder v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+private def _newAnticipatedRDetEvent [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryNDEvent AM α' β') (ev : AnticipatedRDetEventSpec v AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : AnticipatedRDetEvent v AM M α β α' β' :=
   {
     to_Event := ev.to_Event
@@ -87,7 +87,7 @@ with: `abs` the ordinary non-deterministic event to refine, and
   (cf. `AnticipatedRDetEventSpec`).
 -/
 @[simp]
-def newAnticipatedRDetEventfromOrdinary [Preorder v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newAnticipatedRDetEventfromOrdinary [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryNDEvent AM α' β') (ev : AnticipatedRDetEventSpec v AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : AnticipatedRDetEvent v AM M α β α' β' :=
   _newAnticipatedRDetEvent abs ev
 
@@ -97,12 +97,12 @@ with: `abs` the anticipated non-deterministic event to refine, and
   (cf. `AnticipatedRDetEventSpec`).
 -/
 @[simp]
-def newAnticipatedRDetEventfromAnticipated [Preorder v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newAnticipatedRDetEventfromAnticipated [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : AnticipatedNDEvent v AM α' β') (ev : AnticipatedRDetEventSpec v AM M (α:=α) (β:=β) (α':=α') (β':=β') abs.toOrdinaryNDEvent) : AnticipatedRDetEvent v AM M α β α' β' :=
   _newAnticipatedRDetEvent abs.toOrdinaryNDEvent ev
 
 /-- Variant of `AnticipatedRDetEventSpec` with implicit `Unit` output type -/
-structure AnticipatedRDetEventSpec' (v) [Preorder v] (AM) [Machine ACTX AM] (M) [instM:Machine CTX M] [Refinement AM M]
+structure AnticipatedRDetEventSpec' (v) [Preorder v] (AM) [@Machine ACTX AM] (M) [instM:@Machine CTX M] [Refinement AM M]
   {α α'} (abstract : OrdinaryNDEvent AM α' Unit)
   extends _Variant v (instM:=instM), RDetEventSpec' AM M (α:=α) (α':=α') abstract where
 
@@ -113,7 +113,7 @@ structure AnticipatedRDetEventSpec' (v) [Preorder v] (AM) [Machine ACTX AM] (M) 
       variant m' ≤ variant m
 
 @[simp]
-def AnticipatedRDetEventSpec'.toAnticipatedRDetEventSpec [Preorder v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def AnticipatedRDetEventSpec'.toAnticipatedRDetEventSpec [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abstract : OrdinaryNDEvent AM α' Unit)
   (ev : AnticipatedRDetEventSpec' v AM M  (α:=α) (α':=α') abstract) : AnticipatedRDetEventSpec v AM M (α:=α) (β:=Unit) (α':=α') (β':=Unit) abstract :=
   {
@@ -124,18 +124,18 @@ def AnticipatedRDetEventSpec'.toAnticipatedRDetEventSpec [Preorder v] [Machine A
 
 /-- Variant of `newAnticipatedRDetEventFromOrdinary` with implicit `Unit` output type -/
 @[simp]
-def newAnticipatedRDetEventfromOrdinary' [Preorder v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newAnticipatedRDetEventfromOrdinary' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryNDEvent AM α' Unit) (ev : AnticipatedRDetEventSpec' v AM M (α:=α) (α':=α') abs) : AnticipatedRDetEvent v AM M α Unit α' Unit :=
   _newAnticipatedRDetEvent abs ev.toAnticipatedRDetEventSpec
 
 /-- Variant of `newAnticipatedRDetEventFromAnticipated` with implicit `Unit` output type -/
 @[simp]
-def newAnticipatedRDetEventfromAnticipated' [Preorder v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newAnticipatedRDetEventfromAnticipated' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : AnticipatedNDEvent v AM α' Unit) (ev : AnticipatedRDetEventSpec' v AM M (α:=α) (α':=α') abs.toOrdinaryNDEvent) : AnticipatedRDetEvent v AM M α Unit α' Unit :=
   _newAnticipatedRDetEvent abs.toOrdinaryNDEvent ev.toAnticipatedRDetEventSpec
 
 /-- Variant of `AnticipatedRDetEventSpec` with implicit `Unit` input and output types -/
-structure AnticipatedRDetEventSpec'' (v) [Preorder v] (AM) [Machine ACTX AM] (M) [instM:Machine CTX M] [Refinement AM M]
+structure AnticipatedRDetEventSpec'' (v) [Preorder v] (AM) [@Machine ACTX AM] (M) [instM:@Machine CTX M] [Refinement AM M]
   (abstract : OrdinaryNDEvent AM Unit Unit)
   extends _Variant v (instM:=instM), RDetEventSpec'' AM M abstract where
 
@@ -146,7 +146,7 @@ structure AnticipatedRDetEventSpec'' (v) [Preorder v] (AM) [Machine ACTX AM] (M)
       variant m' ≤ variant m
 
 @[simp]
-def AnticipatedRDetEventSpec''.toAnticipatedRDetEventSpec [Preorder v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def AnticipatedRDetEventSpec''.toAnticipatedRDetEventSpec [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abstract : OrdinaryNDEvent AM Unit Unit)
   (ev : AnticipatedRDetEventSpec'' v AM M  abstract) : AnticipatedRDetEventSpec v AM M (α:=Unit) (β:=Unit) (α':=Unit) (β':=Unit) abstract :=
   {
@@ -157,13 +157,13 @@ def AnticipatedRDetEventSpec''.toAnticipatedRDetEventSpec [Preorder v] [Machine 
 
 /-- Variant of `newAnticipatedRDetEventfromOrdinary` with implicit `Unit` input and output types -/
 @[simp]
-def newAnticipatedRDetEventfromOrdinary'' [Preorder v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newAnticipatedRDetEventfromOrdinary'' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryNDEvent AM Unit Unit) (ev : AnticipatedRDetEventSpec'' v AM M abs) : AnticipatedRDetEvent v AM M Unit Unit :=
   _newAnticipatedRDetEvent abs ev.toAnticipatedRDetEventSpec
 
 /-- Variant of `newAnticipatedRDetEventfromAnticipated` with implicit `Unit` input and output types -/
 @[simp]
-def newAnticipatedRDetEventfromAnticipated'' [Preorder v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newAnticipatedRDetEventfromAnticipated'' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : AnticipatedNDEvent v AM Unit Unit) (ev : AnticipatedRDetEventSpec'' v AM M abs.toOrdinaryNDEvent) : AnticipatedRDetEvent v AM M Unit Unit :=
   _newAnticipatedRDetEvent abs.toOrdinaryNDEvent ev.toAnticipatedRDetEventSpec
 
@@ -172,7 +172,7 @@ def newAnticipatedRDetEventfromAnticipated'' [Preorder v] [Machine ACTX AM] [Mac
 -/
 
 /-- Internal representation of proof obligations for convergent deterministic refined events -/
-structure _ConvergentRDetEventPO (v) [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [instR: Refinement AM M]
+structure _ConvergentRDetEventPO (v) [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [instR: Refinement AM M]
           (ev : _Event M α β) (kind : EventKind) (α' β')
           extends _AnticipatedRDetEventPO v (instR:=instR) ev kind α' β' where
 
@@ -185,13 +185,13 @@ structure _ConvergentRDetEventPO (v) [Preorder v] [WellFoundedLT v] [Machine ACT
 /-- The representation of convergent deterministic refined events, constructed
 by specifications structures, e.g. `ConvergentRDetEventSpec`,
  and smart constructors, e.g. `newConvergentRDetEvent`. -/
-structure ConvergentRDetEvent (v) [Preorder v] [WellFoundedLT v] (AM) [Machine ACTX AM] (M) [Machine CTX M] [instR: Refinement AM M]
+structure ConvergentRDetEvent (v) [Preorder v] [WellFoundedLT v] (AM) [@Machine ACTX AM] (M) [@Machine CTX M] [instR: Refinement AM M]
   (α) (β) (α':=α) (β':=β) extends _Event M α β where
   po : _ConvergentRDetEventPO v (instR:=instR) to_Event (EventKind.TransDet Convergence.Convergent) α' β'
 
 
 @[simp]
-def ConvergentRDetEvent.toConvergentEvent [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def ConvergentRDetEvent.toConvergentEvent [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (ev : ConvergentRDetEvent v AM M α β α' β') : ConvergentEvent v M α β :=
   {
     to_Event := ev.to_Event
@@ -215,7 +215,7 @@ The input and output types can be lifted to the abstract, if needed,
 The added proof obligation, beyond `safety` , guard `strengthening`,
 abstract event `simulation`, is a `convergence` requirement.
  -/
-structure ConvergentRDetEventSpec (v) [Preorder v] [WellFoundedLT v] (AM) [Machine ACTX AM] (M) [instM:Machine CTX M] [Refinement AM M]
+structure ConvergentRDetEventSpec (v) [Preorder v] [WellFoundedLT v] (AM) [@Machine ACTX AM] (M) [instM:@Machine CTX M] [Refinement AM M]
   {α β α' β'} (abstract : OrdinaryNDEvent AM α' β')
   extends _Variant v (instM:=instM), RDetEventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abstract where
 
@@ -231,7 +231,7 @@ with: `abs` the event to refine, and
   `ev` the refined event specification (cf. `ConvergentRDetEventSpec`).
 -/
 @[simp]
-def newConvergentRDetEvent [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newConvergentRDetEvent [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryNDEvent AM α' β') (ev : ConvergentRDetEventSpec v AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : ConvergentRDetEvent v AM M α β α' β' :=
   {
     to_Event := ev.to_Event
@@ -252,7 +252,7 @@ def newConvergentRDetEvent [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Mac
   }
 
 /-- Variant of `ConvergentRDetEventSpec` with implicit `Unit` output type -/
-structure ConvergentRDetEventSpec' (v) [Preorder v] [WellFoundedLT v] (AM) [Machine ACTX AM] (M) [instM:Machine CTX M] [Refinement AM M]
+structure ConvergentRDetEventSpec' (v) [Preorder v] [WellFoundedLT v] (AM) [@Machine ACTX AM] (M) [instM:@Machine CTX M] [Refinement AM M]
   {α α'} (abstract : OrdinaryNDEvent AM α' Unit)
   extends _Variant v (instM:=instM), RDetEventSpec' AM M (α:=α) (α':=α') abstract where
 
@@ -263,7 +263,7 @@ structure ConvergentRDetEventSpec' (v) [Preorder v] [WellFoundedLT v] (AM) [Mach
       variant m' < variant m
 
 @[simp]
-def ConvergentRDetEventSpec'.toConvergentRDetEventSpec [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def ConvergentRDetEventSpec'.toConvergentRDetEventSpec [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abstract : OrdinaryNDEvent AM α' Unit)
   (ev : ConvergentRDetEventSpec' v AM M  (α:=α) (α':=α') abstract) : ConvergentRDetEventSpec v AM M (α:=α) (β:=Unit) (α':=α') (β':=Unit) abstract :=
   {
@@ -274,12 +274,12 @@ def ConvergentRDetEventSpec'.toConvergentRDetEventSpec [Preorder v] [WellFounded
 
 /-- Variant of `newConvergentRDetEvent` with implicit `Unit` output type -/
 @[simp]
-def newConvergentRDetEvent' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newConvergentRDetEvent' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryNDEvent AM α' Unit) (ev : ConvergentRDetEventSpec' v AM M (α:=α) (α':=α') abs) : ConvergentRDetEvent v AM M α Unit α' Unit :=
   newConvergentRDetEvent abs ev.toConvergentRDetEventSpec
 
 /-- Variant of `ConvergentRDetEventSpec` with implicit `Unit` input and output types -/
-structure ConvergentRDetEventSpec'' (v) [Preorder v] [WellFoundedLT v] (AM) [Machine ACTX AM] (M) [instM:Machine CTX M] [Refinement AM M]
+structure ConvergentRDetEventSpec'' (v) [Preorder v] [WellFoundedLT v] (AM) [@Machine ACTX AM] (M) [instM:@Machine CTX M] [Refinement AM M]
   (abstract : OrdinaryNDEvent AM Unit Unit)
   extends _Variant v (instM:=instM), RDetEventSpec'' AM M abstract where
 
@@ -290,7 +290,7 @@ structure ConvergentRDetEventSpec'' (v) [Preorder v] [WellFoundedLT v] (AM) [Mac
       variant m' < variant m
 
 @[simp]
-def ConvergentRDetEventSpec''.toConvergentRDetEventSpec [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def ConvergentRDetEventSpec''.toConvergentRDetEventSpec [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abstract : OrdinaryNDEvent AM Unit Unit)
   (ev : ConvergentRDetEventSpec'' v AM M abstract) : ConvergentRDetEventSpec v AM M (α:=Unit) (β:=Unit) (α':=Unit) (β':=Unit) abstract :=
   {
@@ -301,6 +301,6 @@ def ConvergentRDetEventSpec''.toConvergentRDetEventSpec [Preorder v] [WellFounde
 
 /-- Variant of `newConvergentRDetEvent` with implicit `Unit` input and output types -/
 @[simp]
-def newConvergentRDetEvent'' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [Refinement AM M]
+def newConvergentRDetEvent'' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [Refinement AM M]
   (abs : OrdinaryNDEvent AM Unit Unit) (ev : ConvergentRDetEventSpec'' v AM M abs) : ConvergentRDetEvent v AM M Unit Unit :=
   newConvergentRDetEvent abs ev.toConvergentRDetEventSpec

--- a/LeanMachines/Refinement/Strong/Abstract.lean
+++ b/LeanMachines/Refinement/Strong/Abstract.lean
@@ -11,8 +11,8 @@ open Refinement
 open FRefinement
 open SRefinement
 
-structure AbstractSREventSpec (AM) [Machine ACTX AM]
-                             (M) [Machine CTX M]
+structure AbstractSREventSpec (AM) [@Machine ACTX AM]
+                             (M) [@Machine CTX M]
                             [SRefinement AM M]
   {α β} (abstract : OrdinaryEvent AM α β)
           where
@@ -23,7 +23,7 @@ structure AbstractSREventSpec (AM) [Machine ACTX AM]
     → Machine.invariant (unlift m (abstract.action (lift m) x agrd).2)
 
 @[simp]
-def AbstractSREventSpec.toAbstractFREventSpec [Machine ACTX AM] [Machine CTX M] [instSR: SRefinement AM M]
+def AbstractSREventSpec.toAbstractFREventSpec [@Machine ACTX AM] [@Machine CTX M] [instSR: SRefinement AM M]
   (abstract : OrdinaryEvent AM α β)
   (ev : AbstractSREventSpec AM M abstract) : AbstractFREventSpec AM M abstract :=
   {
@@ -47,19 +47,19 @@ def AbstractSREventSpec.toAbstractFREventSpec [Machine ACTX AM] [Machine CTX M] 
   }
 
 @[simp]
-def newAbstractSREvent [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAbstractSREvent [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : OrdinaryEvent AM α β)
   (ev : AbstractSREventSpec AM M abs) : OrdinaryREvent AM M α β :=
   newAbstractFREvent abs ev.toAbstractFREventSpec
 
 @[simp]
-def newAbstractSREvent' [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAbstractSREvent' [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : OrdinaryEvent AM α Unit)
   (ev : AbstractSREventSpec AM M abs) : OrdinaryREvent AM M α Unit :=
   newAbstractFREvent abs ev.toAbstractFREventSpec
 
-structure AbstractSREventSpec'' (AM) [Machine ACTX AM]
-                             (M) [Machine CTX M]
+structure AbstractSREventSpec'' (AM) [@Machine ACTX AM]
+                             (M) [@Machine CTX M]
                             [SRefinement AM M]
   (abstract : OrdinaryEvent AM Unit Unit)
           where
@@ -70,7 +70,7 @@ structure AbstractSREventSpec'' (AM) [Machine ACTX AM]
     → Machine.invariant (unlift m (abstract.action (lift m) x agrd).2)
 
 @[simp]
-def AbstractSREventSpec''.toAbstractSREventSpec [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def AbstractSREventSpec''.toAbstractSREventSpec [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abstract : OrdinaryEvent AM Unit Unit)
   (ev : AbstractSREventSpec'' AM M abstract) : AbstractSREventSpec AM M abstract :=
   {
@@ -78,13 +78,13 @@ def AbstractSREventSpec''.toAbstractSREventSpec [Machine ACTX AM] [Machine CTX M
   }
 
 @[simp]
-def newAbstractSREvent'' [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAbstractSREvent'' [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : OrdinaryEvent AM Unit Unit)
   (ev : AbstractSREventSpec'' AM M abs) : OrdinaryREvent AM M Unit Unit :=
   newAbstractSREvent abs ev.toAbstractSREventSpec
 
-structure AbstractInitSREventSpec (AM) [Machine ACTX AM]
-                             (M) [Machine CTX M]
+structure AbstractInitSREventSpec (AM) [@Machine ACTX AM]
+                             (M) [@Machine CTX M]
                             [instSR: SRefinement AM M]
   {α β} (abstract : InitEvent AM α β)
           where
@@ -94,7 +94,7 @@ structure AbstractInitSREventSpec (AM) [Machine ACTX AM]
     → Machine.invariant (unlift (self:=instSR) default (abstract.init x agrd).2)
 
 @[simp]
-def AbstractInitSREventSpec.toAbstractInitFREventSpec [Machine ACTX AM] [Machine CTX M] [instSR: SRefinement AM M]
+def AbstractInitSREventSpec.toAbstractInitFREventSpec [@Machine ACTX AM] [@Machine CTX M] [instSR: SRefinement AM M]
   (abstract : InitEvent AM α β)
   (ev : AbstractInitSREventSpec AM M abstract) : AbstractInitFREventSpec AM M abstract :=
   {
@@ -118,19 +118,19 @@ def AbstractInitSREventSpec.toAbstractInitFREventSpec [Machine ACTX AM] [Machine
   }
 
 @[simp]
-def newAbstractInitSREvent [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAbstractInitSREvent [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : InitEvent AM α β)
   (ev : AbstractInitSREventSpec AM M abs) : InitREvent AM M α β :=
   newAbstractInitFREvent abs ev.toAbstractInitFREventSpec
 
 @[simp]
-def newAbstractInitSREvent' [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAbstractInitSREvent' [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : InitEvent AM α Unit)
   (ev : AbstractInitSREventSpec AM M abs) : InitREvent AM M α Unit :=
   newAbstractInitFREvent abs ev.toAbstractInitFREventSpec
 
-structure AbstractInitSREventSpec'' (AM) [Machine ACTX AM]
-                             (M) [Machine CTX M]
+structure AbstractInitSREventSpec'' (AM) [@Machine ACTX AM]
+                             (M) [@Machine CTX M]
                             [instSR: SRefinement AM M]
   (abstract : InitEvent AM Unit Unit)
           where
@@ -140,7 +140,7 @@ structure AbstractInitSREventSpec'' (AM) [Machine ACTX AM]
     → Machine.invariant (unlift (self:=instSR) default (abstract.init () agrd).2)
 
 @[simp]
-def AbstractInitSREventSpec''.toAbstractInitSREventSpec [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def AbstractInitSREventSpec''.toAbstractInitSREventSpec [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abstract : InitEvent AM Unit Unit)
   (ev : AbstractInitSREventSpec'' AM M abstract) : AbstractInitSREventSpec AM M abstract :=
   {
@@ -148,13 +148,13 @@ def AbstractInitSREventSpec''.toAbstractInitSREventSpec [Machine ACTX AM] [Machi
   }
 
 @[simp]
-def newAbstractInitSREvent'' [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAbstractInitSREvent'' [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : InitEvent AM Unit Unit)
   (ev : AbstractInitSREventSpec'' AM M abs) : InitREvent AM M Unit Unit :=
   newAbstractInitSREvent abs ev.toAbstractInitSREventSpec
 
 @[simp]
-def AbstractSREventSpec.toAbstractAnticipatedFREventSpec [Preorder v] [Machine ACTX AM] [Machine CTX M] [instSR: SRefinement AM M]
+def AbstractSREventSpec.toAbstractAnticipatedFREventSpec [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [instSR: SRefinement AM M]
   (abstract : AnticipatedEvent v AM α β)
   (ev : AbstractSREventSpec AM M abstract.toOrdinaryEvent) : AbstractAnticipatedFREventSpec v AM M abstract :=
   {
@@ -171,37 +171,37 @@ def AbstractSREventSpec.toAbstractAnticipatedFREventSpec [Preorder v] [Machine A
   }
 
 @[simp]
-def newAbstractAnticipatedSREvent [Preorder v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAbstractAnticipatedSREvent [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : AnticipatedEvent v AM α β)
   (ev : AbstractSREventSpec AM M abs.toOrdinaryEvent) : AnticipatedREvent v AM M α β :=
   newAbstractAnticipatedFREvent abs ev.toAbstractAnticipatedFREventSpec
 
 @[simp]
-def newAbstractAnticipatedSREvent' [Preorder v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAbstractAnticipatedSREvent' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : AnticipatedEvent v AM α Unit)
   (ev : AbstractSREventSpec AM M abs.toOrdinaryEvent) : AnticipatedREvent v AM M α Unit :=
   newAbstractAnticipatedFREvent abs ev.toAbstractAnticipatedFREventSpec
 
 @[simp]
-def newAbstractAnticipatedSREvent'' [Preorder v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAbstractAnticipatedSREvent'' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : AnticipatedEvent v AM Unit Unit)
   (ev : AbstractSREventSpec'' AM M abs.toOrdinaryEvent) : AnticipatedREvent v AM M Unit Unit :=
   newAbstractAnticipatedSREvent abs ev.toAbstractSREventSpec
 
 @[simp]
-def newAbstractConvergentSREvent [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAbstractConvergentSREvent [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : ConvergentEvent v AM α β)
   (ev : AbstractSREventSpec AM M abs.toOrdinaryEvent) : ConvergentREvent v AM M α β :=
   newAbstractConvergentFREvent abs (ev.toAbstractAnticipatedFREventSpec abs.toAnticipatedEvent)
 
 @[simp]
-def newAbstractConvergentSREvent' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAbstractConvergentSREvent' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : ConvergentEvent v AM α Unit)
   (ev : AbstractSREventSpec AM M abs.toOrdinaryEvent) : ConvergentREvent v AM M α Unit :=
   newAbstractConvergentFREvent abs (ev.toAbstractAnticipatedFREventSpec abs.toAnticipatedEvent)
 
 @[simp]
-def newAbstractConvergentSREvent'' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAbstractConvergentSREvent'' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : ConvergentEvent v AM Unit Unit)
   (ev : AbstractSREventSpec'' AM M abs.toOrdinaryEvent) : ConvergentREvent v AM M Unit Unit :=
   newAbstractConvergentSREvent abs ev.toAbstractSREventSpec

--- a/LeanMachines/Refinement/Strong/Basic.lean
+++ b/LeanMachines/Refinement/Strong/Basic.lean
@@ -39,7 +39,7 @@ However, the requirements are now promoted to the machine-level.
 -/
 class SRefinement {ACTX : outParam (Type u₁)} (AM)
                  {CTX : outParam (Type u₂)} (M)
-                 [Machine ACTX AM] [Machine CTX M] extends FRefinement AM M where
+                 [@Machine ACTX AM] [@Machine CTX M] extends FRefinement AM M where
 
   /-- Reconstruction of a concrete post-state from a concrete-pre state `m`
    and an abstract post-state `am'`.
@@ -61,7 +61,7 @@ class SRefinement {ACTX : outParam (Type u₁)} (AM)
 open Refinement
 open SRefinement
 
-theorem unlift_refine [Machine ACTX AM] [Machine CTX M] [instSR:SRefinement AM M] {m : M} {am : AM}:
+theorem unlift_refine [@Machine ACTX AM] [@Machine CTX M] [instSR:SRefinement AM M] {m : M} {am : AM}:
     Machine.invariant m → Machine.invariant am → refine am (unlift m am) := by
   intro Hinv₁ Hinv₂
   have Href: refine (self:=inferInstanceAs (Refinement AM M)) (lift (unlift m am)) (unlift m am) := rfl
@@ -81,33 +81,33 @@ cf. the module `Refinement.Functional.Basic` for further documentation.
 -/
 
 @[simp]
-def newSREvent [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newSREvent [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : OrdinaryEvent AM α' β') (ev : FREventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : OrdinaryREvent AM M α β α' β' :=
   newREvent abs ev.toREventSpec
 
 @[simp]
-def newSREvent' [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newSREvent' [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : OrdinaryEvent AM α' Unit) (ev : FREventSpec' AM M (α:=α) (α':=α') abs) : OrdinaryREvent AM M α Unit α' Unit :=
   newSREvent abs ev.toFREventSpec
 
 @[simp]
-def newSREvent'' [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newSREvent'' [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : OrdinaryEvent AM Unit Unit) (ev : FREventSpec'' AM M abs) : OrdinaryREvent AM M Unit Unit :=
   newSREvent abs ev.toFREventSpec
 
 /- Initialization events -/
 
 @[simp]
-def newInitSREvent [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newInitSREvent [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : InitEvent AM α' β') (ev : InitFREventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : InitREvent AM M α β α' β' :=
   newInitREvent abs ev.toInitREventSpec
 
 @[simp]
-def newInitSREvent' [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newInitSREvent' [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : InitEvent AM α' Unit) (ev : InitFREventSpec' AM M (α:=α) (α':=α') abs) : InitREvent AM M α Unit α' Unit :=
   newInitSREvent abs ev.toInitFREventSpec
 
 @[simp]
-def newInitSREvent'' [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newInitSREvent'' [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : InitEvent AM Unit Unit) (ev : InitFREventSpec'' AM M abs) : InitREvent AM M Unit Unit :=
   newInitSREvent abs ev.toInitFREventSpec

--- a/LeanMachines/Refinement/Strong/Concrete.lean
+++ b/LeanMachines/Refinement/Strong/Concrete.lean
@@ -7,17 +7,17 @@ open FRefinement
 open SRefinement
 
 @[simp]
-def newConcreteSREvent [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newConcreteSREvent [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
    (ev : ConcreteFREventSpec AM M α β) : OrdinaryRDetEvent AM M α β :=
   newConcreteFREvent ev
 
 @[simp]
-def newConcreteSREvent' [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newConcreteSREvent' [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
    (ev : ConcreteFREventSpec' AM M α) : OrdinaryRDetEvent AM M α Unit :=
   newConcreteFREvent ev.toConcreteFREventSpec
 
 @[simp]
-def newConcreteSREvent'' [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newConcreteSREvent'' [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
    (ev : ConcreteFREventSpec'' AM M) : OrdinaryRDetEvent AM M Unit Unit :=
   newConcreteFREvent ev.toConcreteFREventSpec
 
@@ -25,19 +25,19 @@ def newConcreteSREvent'' [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
 
 @[simp]
 def newConcreteAnticipatedSREvent [Preorder v] [WellFoundedLT v]
-                       [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+                       [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
    (ev : ConcreteAnticipatedFREventSpec v AM M α β) : AnticipatedRDetEvent v AM M α β :=
   newConcreteAnticipatedFREvent ev
 
 @[simp]
 def newConcreteAnticipatedSREvent' [Preorder v] [WellFoundedLT v]
-                       [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+                       [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
    (ev : ConcreteAnticipatedFREventSpec' v AM M α) : AnticipatedRDetEvent v AM M α Unit :=
   newConcreteAnticipatedREvent ev.toConcreteAnticipatedREventSpec
 
 @[simp]
 def newConcreteAnticipatedSREvent'' [Preorder v] [WellFoundedLT v]
-                       [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+                       [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
    (ev : ConcreteAnticipatedFREventSpec'' v AM M) : AnticipatedRDetEvent v AM M Unit Unit :=
   newConcreteAnticipatedFREvent ev.toConcreteAnticipatedFREventSpec
 
@@ -46,18 +46,18 @@ def newConcreteAnticipatedSREvent'' [Preorder v] [WellFoundedLT v]
 
 @[simp]
 def newConcreteConvergentSREvent [Preorder v] [WellFoundedLT v]
-                       [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+                       [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
    (ev : ConcreteConvergentFREventSpec v AM M α β) : ConvergentRDetEvent v AM M α β :=
   newConcreteConvergentFREvent ev
 
 @[simp]
 def newConcreteConvergentSREvent' [Preorder v] [WellFoundedLT v]
-                       [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+                       [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
    (ev : ConcreteConvergentFREventSpec' v AM M α) : ConvergentRDetEvent v AM M α Unit :=
   newConcreteConvergentREvent ev.toConcreteConvergentREventSpec
 
 @[simp]
 def newConcreteConvergentSREvent'' [Preorder v] [WellFoundedLT v]
-                       [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+                       [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
    (ev : ConcreteConvergentFREventSpec'' v AM M) : ConvergentRDetEvent v AM M Unit Unit :=
   newConcreteConvergentFREvent ev.toConcreteConvergentFREventSpec

--- a/LeanMachines/Refinement/Strong/Convergent.lean
+++ b/LeanMachines/Refinement/Strong/Convergent.lean
@@ -4,52 +4,52 @@ import LeanMachines.Refinement.Relational.Convergent
 import LeanMachines.Refinement.Functional.Convergent
 
 @[simp]
-def newAnticipatedSREventfromOrdinary [Preorder v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAnticipatedSREventfromOrdinary [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : OrdinaryEvent AM α' β')
   (ev : AnticipatedFREventSpec v AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : AnticipatedREvent v AM M α β α' β' :=
   newAnticipatedFREventfromOrdinary abs ev
 
 @[simp]
-def newAnticipatedSREventfromOrdinary' [Preorder v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAnticipatedSREventfromOrdinary' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : OrdinaryEvent AM α' Unit)
   (ev : AnticipatedFREventSpec' v AM M (α:=α) (α':=α') abs) : AnticipatedREvent v AM M α Unit α' Unit :=
   newAnticipatedSREventfromOrdinary abs ev.toAnticipatedFREventSpec
 
 @[simp]
-def newAnticipatedSREventfromOrdinary'' [Preorder v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAnticipatedSREventfromOrdinary'' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : OrdinaryEvent AM Unit Unit)
   (ev : AnticipatedFREventSpec'' v AM M abs) : AnticipatedREvent v AM M Unit Unit :=
   newAnticipatedSREventfromOrdinary abs ev.toAnticipatedFREventSpec
 
 @[simp]
-def newAnticipatedSREventfromAnticipated [Preorder v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAnticipatedSREventfromAnticipated [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : AnticipatedEvent v AM α' β')
   (ev : AnticipatedFREventSpec v AM M (α:=α) (β:=β) (α':=α') (β':=β') abs.toOrdinaryEvent) : AnticipatedREvent v AM M α β α' β' :=
   newAnticipatedFREventfromAnticipated abs ev
 
 @[simp]
-def newAnticipatedSREventfromAnticipated' [Preorder v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAnticipatedSREventfromAnticipated' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : AnticipatedEvent v AM α' Unit)
   (ev : AnticipatedFREventSpec' v AM M (α:=α) (α':=α') abs.toOrdinaryEvent) : AnticipatedREvent v AM M α Unit α' Unit :=
   newAnticipatedSREventfromAnticipated abs ev.toAnticipatedFREventSpec
 
 @[simp]
-def newAnticipatedSREventfromAnticipated'' [Preorder v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAnticipatedSREventfromAnticipated'' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : AnticipatedEvent v AM Unit Unit)
   (ev : AnticipatedFREventSpec'' v AM M abs.toOrdinaryEvent) : AnticipatedREvent v AM M Unit Unit :=
   newAnticipatedSREventfromAnticipated abs ev.toAnticipatedFREventSpec
 
 @[simp]
-def newConvergentSREvent [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newConvergentSREvent [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : OrdinaryEvent AM α' β') (ev : ConvergentFREventSpec v AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : ConvergentREvent v AM M α β α' β' :=
   newConvergentFREvent abs ev
 
 @[simp]
-def newConvergentSREvent' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newConvergentSREvent' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : OrdinaryEvent AM α' Unit) (ev : ConvergentFREventSpec' v AM M (α:=α) (α':=α') abs) : ConvergentREvent v AM M α Unit α' Unit :=
   newConvergentSREvent abs ev.toConvergentFREventSpec
 
 @[simp]
-def newConvergentSREvent'' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newConvergentSREvent'' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : OrdinaryEvent AM Unit Unit) (ev : ConvergentFREventSpec'' v AM M abs) : ConvergentREvent v AM M Unit Unit :=
   newConvergentSREvent abs ev.toConvergentFREventSpec

--- a/LeanMachines/Refinement/Strong/NonDet/Abstract.lean
+++ b/LeanMachines/Refinement/Strong/NonDet/Abstract.lean
@@ -6,8 +6,8 @@ open Refinement
 open FRefinement
 open SRefinement
 
-structure AbstractSRNDEventSpec (AM) [Machine ACTX AM]
-                             (M) [Machine CTX M]
+structure AbstractSRNDEventSpec (AM) [@Machine ACTX AM]
+                             (M) [@Machine CTX M]
                             [instSR: SRefinement AM M]
   {α β} (abstract : OrdinaryNDEvent AM α β)
       where
@@ -19,7 +19,7 @@ structure AbstractSRNDEventSpec (AM) [Machine ACTX AM]
                   → Machine.invariant (unlift m am')
 
 @[simp]
-def AbstractSRNDEventSpec.toAbstractFRNDEventSpec  [Machine ACTX AM] [Machine CTX M] [instSR: SRefinement AM M]
+def AbstractSRNDEventSpec.toAbstractFRNDEventSpec  [@Machine ACTX AM] [@Machine CTX M] [instSR: SRefinement AM M]
   (abstract : OrdinaryNDEvent AM α β)
   (ev : AbstractSRNDEventSpec AM M abstract) : AbstractFRNDEventSpec AM M abstract :=
   {
@@ -46,13 +46,13 @@ def AbstractSRNDEventSpec.toAbstractFRNDEventSpec  [Machine ACTX AM] [Machine CT
   }
 
 @[simp]
-def newAbstractSRNDEvent [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAbstractSRNDEvent [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : OrdinaryNDEvent AM α β)
   (ev : AbstractSRNDEventSpec AM M abs) : OrdinaryRNDEvent AM M α β :=
   newAbstractFRNDEvent abs ev.toAbstractFRNDEventSpec
 
-structure AbstractSRNDEventSpec' (AM) [Machine ACTX AM]
-                             (M) [Machine CTX M]
+structure AbstractSRNDEventSpec' (AM) [@Machine ACTX AM]
+                             (M) [@Machine CTX M]
                             [instSR: SRefinement AM M]
   {α} (abstract : OrdinaryNDEvent AM α Unit)
       where
@@ -64,7 +64,7 @@ structure AbstractSRNDEventSpec' (AM) [Machine ACTX AM]
              → Machine.invariant (unlift m am')
 
 @[simp]
-def AbstractSRNDEventSpec'.toAbstractSRNDEventSpec [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def AbstractSRNDEventSpec'.toAbstractSRNDEventSpec [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abstract : OrdinaryNDEvent AM α Unit)
   (ev : AbstractSRNDEventSpec' AM M abstract) : AbstractSRNDEventSpec AM M abstract :=
   {
@@ -72,13 +72,13 @@ def AbstractSRNDEventSpec'.toAbstractSRNDEventSpec [Machine ACTX AM] [Machine CT
   }
 
 @[simp]
-def newAbstractSRNDEvent' [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAbstractSRNDEvent' [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : OrdinaryNDEvent AM α Unit)
   (ev : AbstractSRNDEventSpec' AM M abs) : OrdinaryRNDEvent AM M α Unit :=
   newAbstractSRNDEvent abs ev.toAbstractSRNDEventSpec
 
-structure AbstractSRNDEventSpec'' (AM) [Machine ACTX AM]
-                             (M) [Machine CTX M]
+structure AbstractSRNDEventSpec'' (AM) [@Machine ACTX AM]
+                             (M) [@Machine CTX M]
                             [instSR: SRefinement AM M]
   (abstract : OrdinaryNDEvent AM Unit Unit)
       where
@@ -90,7 +90,7 @@ structure AbstractSRNDEventSpec'' (AM) [Machine ACTX AM]
              → Machine.invariant (unlift m am')
 
 @[simp]
-def AbstractSRNDEventSpec''.toAbstractSRNDEventSpec  [Machine ACTX AM] [Machine CTX M] [instSR: SRefinement AM M]
+def AbstractSRNDEventSpec''.toAbstractSRNDEventSpec  [@Machine ACTX AM] [@Machine CTX M] [instSR: SRefinement AM M]
   (abstract : OrdinaryNDEvent AM Unit Unit)
   (ev : AbstractSRNDEventSpec'' AM M abstract) : AbstractSRNDEventSpec AM M abstract :=
   {
@@ -100,13 +100,13 @@ def AbstractSRNDEventSpec''.toAbstractSRNDEventSpec  [Machine ACTX AM] [Machine 
   }
 
 @[simp]
-def newAbstractSRNDEvent'' [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAbstractSRNDEvent'' [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : OrdinaryNDEvent AM Unit Unit)
   (ev : AbstractSRNDEventSpec'' AM M abs) : OrdinaryRNDEvent AM M Unit Unit :=
   newAbstractSRNDEvent abs ev.toAbstractSRNDEventSpec
 
-structure AbstractInitSRNDEventSpec (AM) [Machine ACTX AM]
-                             (M) [Machine CTX M]
+structure AbstractInitSRNDEventSpec (AM) [@Machine ACTX AM]
+                             (M) [@Machine CTX M]
                             [instSR: SRefinement AM M]
   {α β} (abstract : InitNDEvent AM α β)
       where
@@ -117,7 +117,7 @@ structure AbstractInitSRNDEventSpec (AM) [Machine ACTX AM]
                   → Machine.invariant (M:=M) (unlift default am')
 
 @[simp]
-def AbstractInitSRNDEventSpec.toAbstractInitFRNDEventSpec  [Machine ACTX AM] [Machine CTX M] [instSR: SRefinement AM M]
+def AbstractInitSRNDEventSpec.toAbstractInitFRNDEventSpec  [@Machine ACTX AM] [@Machine CTX M] [instSR: SRefinement AM M]
   (abstract : InitNDEvent AM α β)
   (ev : AbstractInitSRNDEventSpec AM M abstract) : AbstractInitFRNDEventSpec AM M abstract :=
   {
@@ -145,13 +145,13 @@ def AbstractInitSRNDEventSpec.toAbstractInitFRNDEventSpec  [Machine ACTX AM] [Ma
   }
 
 @[simp]
-def newAbstractInitSRNDEvent [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAbstractInitSRNDEvent [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : InitNDEvent AM α β)
   (ev : AbstractInitSRNDEventSpec AM M abs) : InitRNDEvent AM M α β :=
   newAbstractInitFRNDEvent abs ev.toAbstractInitFRNDEventSpec
 
-structure AbstractInitSRNDEventSpec' (AM) [Machine ACTX AM]
-                             (M) [Machine CTX M]
+structure AbstractInitSRNDEventSpec' (AM) [@Machine ACTX AM]
+                             (M) [@Machine CTX M]
                             [instSR: SRefinement AM M]
   {α} (abstract : InitNDEvent AM α Unit)
       where
@@ -162,7 +162,7 @@ structure AbstractInitSRNDEventSpec' (AM) [Machine ACTX AM]
              → Machine.invariant (M:=M) (unlift default am')
 
 @[simp]
-def AbstractInitSRNDEventSpec'.toAbstractInitSRNDEventSpec  [Machine ACTX AM] [Machine CTX M] [instSR: SRefinement AM M]
+def AbstractInitSRNDEventSpec'.toAbstractInitSRNDEventSpec  [@Machine ACTX AM] [@Machine CTX M] [instSR: SRefinement AM M]
   (abstract : InitNDEvent AM α Unit)
   (ev : AbstractInitSRNDEventSpec' AM M abstract) : AbstractInitSRNDEventSpec AM M abstract :=
   {
@@ -172,13 +172,13 @@ def AbstractInitSRNDEventSpec'.toAbstractInitSRNDEventSpec  [Machine ACTX AM] [M
   }
 
 @[simp]
-def newAbstractInitSRNDEvent' [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAbstractInitSRNDEvent' [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : InitNDEvent AM α Unit)
   (ev : AbstractInitSRNDEventSpec' AM M abs) : InitRNDEvent AM M α Unit :=
   newAbstractInitSRNDEvent abs ev.toAbstractInitSRNDEventSpec
 
-structure AbstractInitSRNDEventSpec'' (AM) [Machine ACTX AM]
-                             (M) [Machine CTX M]
+structure AbstractInitSRNDEventSpec'' (AM) [@Machine ACTX AM]
+                             (M) [@Machine CTX M]
                             [instSR: SRefinement AM M]
   (abstract : InitNDEvent AM Unit Unit)
       where
@@ -189,7 +189,7 @@ structure AbstractInitSRNDEventSpec'' (AM) [Machine ACTX AM]
              → Machine.invariant (M:=M) (unlift default am')
 
 @[simp]
-def AbstractInitSRNDEventSpec''.toAbstractInitSRNDEventSpec  [Machine ACTX AM] [Machine CTX M] [instSR: SRefinement AM M]
+def AbstractInitSRNDEventSpec''.toAbstractInitSRNDEventSpec  [@Machine ACTX AM] [@Machine CTX M] [instSR: SRefinement AM M]
   (abstract : InitNDEvent AM Unit Unit)
   (ev : AbstractInitSRNDEventSpec'' AM M abstract) : AbstractInitSRNDEventSpec AM M abstract :=
   {
@@ -199,41 +199,41 @@ def AbstractInitSRNDEventSpec''.toAbstractInitSRNDEventSpec  [Machine ACTX AM] [
   }
 
 @[simp]
-def newAbstractInitSRNDEvent'' [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAbstractInitSRNDEvent'' [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : InitNDEvent AM Unit Unit)
   (ev : AbstractInitSRNDEventSpec'' AM M abs) : InitRNDEvent AM M Unit Unit :=
   newAbstractInitSRNDEvent abs ev.toAbstractInitSRNDEventSpec
 
 
 @[simp]
-def newAbstractAnticipatedSRNDEvent [Preorder v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAbstractAnticipatedSRNDEvent [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : AnticipatedNDEvent v AM α β)
   (ev : AbstractSRNDEventSpec AM M abs.toOrdinaryNDEvent) : AnticipatedRNDEvent v AM M α β :=
   newAbstractAnticipatedFRNDEvent abs (ev.toAbstractFRNDEventSpec abs.toOrdinaryNDEvent)
 
 @[simp]
-def newAbstractAnticipatedSRNDEvent' [Preorder v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAbstractAnticipatedSRNDEvent' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : AnticipatedNDEvent v AM α Unit)
   (ev : AbstractSRNDEventSpec' AM M abs.toOrdinaryNDEvent) : AnticipatedRNDEvent v AM M α Unit :=
   newAbstractAnticipatedSRNDEvent abs ev.toAbstractSRNDEventSpec
 
 @[simp]
-def newAbstractAnticipatedSRNDEvent'' [Preorder v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAbstractAnticipatedSRNDEvent'' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : AnticipatedNDEvent v AM Unit Unit)
   (ev : AbstractSRNDEventSpec'' AM M abs.toOrdinaryNDEvent) : AnticipatedRNDEvent v AM M Unit Unit :=
   newAbstractAnticipatedSRNDEvent abs ev.toAbstractSRNDEventSpec
 
 @[simp]
-def newAbstractConvergentSRNDEvent [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAbstractConvergentSRNDEvent [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : ConvergentNDEvent v AM α β) (ev : AbstractSRNDEventSpec AM M abs.toAnticipatedNDEvent.toOrdinaryNDEvent) : ConvergentRNDEvent v AM M α β :=
   newAbstractConvergentFRNDEvent abs (ev.toAbstractFRNDEventSpec abs.toAnticipatedNDEvent.toOrdinaryNDEvent)
 
 @[simp]
-def newAbstractConvergentSRNDEvent' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAbstractConvergentSRNDEvent' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : ConvergentNDEvent v AM α Unit) (ev : AbstractSRNDEventSpec' AM M abs.toAnticipatedNDEvent.toOrdinaryNDEvent) : ConvergentRNDEvent v AM M α Unit :=
   newAbstractConvergentSRNDEvent abs ev.toAbstractSRNDEventSpec
 
 @[simp]
-def newAbstractConvergentSRNDEvent'' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAbstractConvergentSRNDEvent'' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : ConvergentNDEvent v AM Unit Unit) (ev : AbstractSRNDEventSpec' AM M abs.toAnticipatedNDEvent.toOrdinaryNDEvent) : ConvergentRNDEvent v AM M Unit Unit :=
   newAbstractConvergentSRNDEvent abs ev.toAbstractSRNDEventSpec

--- a/LeanMachines/Refinement/Strong/NonDet/Basic.lean
+++ b/LeanMachines/Refinement/Strong/NonDet/Basic.lean
@@ -9,31 +9,31 @@ open FRefinement
 open SRefinement
 
 @[simp]
-def newSRNDEvent [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newSRNDEvent [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
 (abs : OrdinaryNDEvent AM α' β') (ev : FRNDEventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : OrdinaryRNDEvent AM M α β α' β' :=
   newRNDEvent abs ev.toRNDEventSpec
 
 @[simp]
-def newSRNDEvent' [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newSRNDEvent' [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
 (abs : OrdinaryNDEvent AM α' Unit) (ev : FRNDEventSpec' AM M (α:=α) (α':=α') abs) : OrdinaryRNDEvent AM M α Unit α' Unit :=
   newSRNDEvent abs ev.toFRNDEventSpec
 
 @[simp]
-def newSRNDEvent'' [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newSRNDEvent'' [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
 (abs : OrdinaryNDEvent AM Unit Unit) (ev : FRNDEventSpec'' AM M abs) : OrdinaryRNDEvent AM M Unit Unit :=
   newSRNDEvent abs ev.toFRNDEventSpec
 
 @[simp]
-def newInitSRNDEvent [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newInitSRNDEvent [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : InitNDEvent AM α' β') (ev : InitFRNDEventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : InitRNDEvent AM M α β α' β' :=
   newInitRNDEvent abs ev.toInitRNDEventSpec
 
 @[simp]
-def newInitSRNDEvent' [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newInitSRNDEvent' [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : InitNDEvent AM α' Unit) (ev : InitFRNDEventSpec' AM M (α:=α) (α':=α') abs) : InitRNDEvent AM M α Unit α' Unit :=
   newInitSRNDEvent abs ev.toInitFRNDEventSpec
 
 @[simp]
-def newInitSRNDEvent'' [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newInitSRNDEvent'' [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : InitNDEvent AM Unit Unit) (ev : InitFRNDEventSpec'' AM M abs) : InitRNDEvent AM M Unit Unit :=
   newInitSRNDEvent abs ev.toInitFRNDEventSpec

--- a/LeanMachines/Refinement/Strong/NonDet/Concrete.lean
+++ b/LeanMachines/Refinement/Strong/NonDet/Concrete.lean
@@ -6,34 +6,34 @@ open FRefinement
 open SRefinement
 
 @[simp]
-def newConcreteSRNDEvent [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newConcreteSRNDEvent [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (ev : ConcreteFRNDEventSpec AM M α β) : OrdinaryRNDEvent AM M α β :=
   newConcreteFRNDEvent ev
 
 @[simp]
-def newConcreteSRNDEvent' [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newConcreteSRNDEvent' [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (ev : ConcreteFRNDEventSpec' AM M α) : OrdinaryRNDEvent AM M α Unit :=
   newConcreteSRNDEvent ev.toConcreteFRNDEventSpec
 
 @[simp]
-def newConcreteSRNDEvent'' [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newConcreteSRNDEvent'' [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (ev : ConcreteFRNDEventSpec'' AM M) : OrdinaryRNDEvent AM M Unit Unit :=
   newConcreteSRNDEvent ev.toConcreteFRNDEventSpec
 
 /- Anticipated concrete events -/
 
 @[simp]
-def newConcreteAnticipatedSRNDEvent [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newConcreteAnticipatedSRNDEvent [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (ev : ConcreteAnticipatedFRNDEventSpec v AM M α β) : AnticipatedRNDEvent v AM M α β :=
   newConcreteAnticipatedFRNDEvent ev
 
 @[simp]
-def newConcreteAnticipatedSRNDEvent' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newConcreteAnticipatedSRNDEvent' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (ev : ConcreteAnticipatedFRNDEventSpec' v AM M α) : AnticipatedRNDEvent v AM M α Unit :=
   newConcreteAnticipatedSRNDEvent ev.toConcreteAnticipatedFRNDEventSpec
 
 @[simp]
-def newConcreteAnticipatedSRNDEvent'' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newConcreteAnticipatedSRNDEvent'' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (ev : ConcreteAnticipatedFRNDEventSpec'' v AM M) : AnticipatedRNDEvent v AM M Unit Unit :=
   newConcreteAnticipatedSRNDEvent ev.toConcreteAnticipatedFRNDEventSpec
 
@@ -41,16 +41,16 @@ def newConcreteAnticipatedSRNDEvent'' [Preorder v] [WellFoundedLT v] [Machine AC
 /- Convergent concrete events -/
 
 @[simp]
-def newConcreteConvergentSRNDEvent [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newConcreteConvergentSRNDEvent [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (ev : ConcreteConvergentFRNDEventSpec v AM M α β) : ConvergentRNDEvent v AM M α β :=
   newConcreteConvergentFRNDEvent ev
 
 @[simp]
-def newConcreteConvergentSRNDEvent' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newConcreteConvergentSRNDEvent' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (ev : ConcreteConvergentFRNDEventSpec' v AM M α) : ConvergentRNDEvent v AM M α Unit :=
   newConcreteConvergentSRNDEvent ev.toConcreteConvergentFRNDEventSpec
 
 @[simp]
-def newConcreteConvergentSRNDEvent'' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newConcreteConvergentSRNDEvent'' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (ev : ConcreteConvergentFRNDEventSpec'' v AM M) : ConvergentRNDEvent v AM M Unit Unit :=
   newConcreteConvergentSRNDEvent ev.toConcreteConvergentFRNDEventSpec

--- a/LeanMachines/Refinement/Strong/NonDet/Convergent.lean
+++ b/LeanMachines/Refinement/Strong/NonDet/Convergent.lean
@@ -7,52 +7,52 @@ open FRefinement
 open SRefinement
 
 @[simp]
-def newAnticipatedSRNDEventFromOrdinary [Preorder v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAnticipatedSRNDEventFromOrdinary [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : OrdinaryNDEvent AM α' β')
   (ev : AnticipatedRNDEventSpec v AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : AnticipatedRNDEvent v AM M α β α' β' :=
   newAnticipatedRNDEventfromOrdinary abs ev
 
 @[simp]
-def newAnticipatedSRNDEventFromOrdinary' [Preorder v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAnticipatedSRNDEventFromOrdinary' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : OrdinaryNDEvent AM α' Unit)
   (ev : AnticipatedRNDEventSpec' v AM M (α:=α) (α':=α') abs) : AnticipatedRNDEvent v AM M α Unit α' Unit :=
    newAnticipatedSRNDEventFromOrdinary abs ev.toAnticipatedRNDEventSpec
 
 @[simp]
-def newAnticipatedSRNDEventFromOrdinary'' [Preorder v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAnticipatedSRNDEventFromOrdinary'' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : OrdinaryNDEvent AM Unit Unit)
   (ev : AnticipatedRNDEventSpec'' v AM M abs) : AnticipatedRNDEvent v AM M Unit Unit :=
    newAnticipatedSRNDEventFromOrdinary abs ev.toAnticipatedRNDEventSpec
 
 @[simp]
-def newAnticipatedSRNDEventFromAnticipated [Preorder v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAnticipatedSRNDEventFromAnticipated [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : AnticipatedNDEvent v AM α' β')
   (ev : AnticipatedRNDEventSpec v AM M (α:=α) (β:=β) (α':=α') (β':=β') abs.toOrdinaryNDEvent) : AnticipatedRNDEvent v AM M α β α' β' :=
   newAnticipatedRNDEventfromAnticipated abs ev
 
 @[simp]
-def newAnticipatedSRNDEventFromAnticipated' [Preorder v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAnticipatedSRNDEventFromAnticipated' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : AnticipatedNDEvent v AM α' Unit)
   (ev : AnticipatedRNDEventSpec' v AM M (α:=α) (α':=α') abs.toOrdinaryNDEvent) : AnticipatedRNDEvent v AM M α Unit α' Unit :=
   newAnticipatedSRNDEventFromAnticipated abs ev.toAnticipatedRNDEventSpec
 
 @[simp]
-def newAnticipatedSRNDEventFromAnticipated'' [Preorder v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAnticipatedSRNDEventFromAnticipated'' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : AnticipatedNDEvent v AM Unit Unit)
   (ev : AnticipatedRNDEventSpec'' v AM M abs.toOrdinaryNDEvent) : AnticipatedRNDEvent v AM M Unit Unit :=
   newAnticipatedSRNDEventFromAnticipated abs ev.toAnticipatedRNDEventSpec
 
 @[simp]
-def newConvergentSRNDEvent [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newConvergentSRNDEvent [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : OrdinaryNDEvent AM α' β') (ev : ConvergentRNDEventSpec v AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : ConvergentRNDEvent v AM M α β α' β' :=
   newConvergentRNDEvent abs ev
 
 @[simp]
-def newConvergentSRNDEvent' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newConvergentSRNDEvent' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : OrdinaryNDEvent AM α' Unit) (ev : ConvergentRNDEventSpec' v AM M (α:=α) (α':=α') abs) : ConvergentRNDEvent v AM M α Unit α' Unit :=
   newConvergentSRNDEvent abs ev.toConvergentRNDEventSpec
 
 @[simp]
-def newConvergentSRNDEvent'' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newConvergentSRNDEvent'' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : OrdinaryNDEvent AM Unit Unit) (ev : ConvergentRNDEventSpec'' v AM M abs) : ConvergentRNDEvent v AM M Unit Unit :=
   newConvergentSRNDEvent abs ev.toConvergentRNDEventSpec

--- a/LeanMachines/Refinement/Strong/NonDet/Det/Basic.lean
+++ b/LeanMachines/Refinement/Strong/NonDet/Det/Basic.lean
@@ -7,19 +7,19 @@ open FRefinement
 open SRefinement
 
 @[simp]
-def newSRDetEvent [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newSRDetEvent [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : OrdinaryNDEvent AM α' β')
   (ev : FRDetEventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : OrdinaryRDetEvent AM M α β α' β':=
   newRDetEvent abs ev.toRDetEventSpec
 
 @[simp]
-def newSRDetEvent' [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newSRDetEvent' [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : OrdinaryNDEvent AM α' Unit)
   (ev : FRDetEventSpec' AM M (α:=α) (α':=α') abs) : OrdinaryRDetEvent AM M α Unit α' Unit:=
   newSRDetEvent abs ev.toFRDetEventSpec
 
 @[simp]
-def newSRDetEvent'' [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newSRDetEvent'' [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : OrdinaryNDEvent AM Unit Unit)
   (ev : FRDetEventSpec'' AM M abs) : OrdinaryRDetEvent AM M Unit Unit:=
   newSRDetEvent abs ev.toFRDetEventSpec
@@ -27,19 +27,19 @@ def newSRDetEvent'' [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
 /- Initialization events -/
 
 @[simp]
-def newInitSRDetEvent [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newInitSRDetEvent [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : InitNDEvent AM α' β')
   (ev : InitFRDetEventSpec AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : InitRDetEvent AM M α β α' β' :=
   newInitRDetEvent abs ev.toInitRDetEventSpec
 
 @[simp]
-def newInitSRDetEvent' [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newInitSRDetEvent' [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : InitNDEvent AM α' Unit)
   (ev : InitFRDetEventSpec' AM M (α:=α) (α':=α') abs) : InitRDetEvent AM M α Unit α' Unit :=
   newInitSRDetEvent abs ev.toInitFRDetEventSpec
 
 @[simp]
-def newInitSRDetEvent'' [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newInitSRDetEvent'' [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : InitNDEvent AM Unit Unit)
   (ev : InitFRDetEventSpec'' AM M abs) : InitRDetEvent AM M Unit Unit :=
   newInitSRDetEvent abs ev.toInitFRDetEventSpec

--- a/LeanMachines/Refinement/Strong/NonDet/Det/Convergent.lean
+++ b/LeanMachines/Refinement/Strong/NonDet/Det/Convergent.lean
@@ -10,46 +10,46 @@ open SRefinement
 
 
 @[simp]
-def newAnticipatedSRDetEventfromOrdinary [Preorder v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAnticipatedSRDetEventfromOrdinary [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : OrdinaryNDEvent AM α' β') (ev : AnticipatedRDetEventSpec v AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : AnticipatedRDetEvent v AM M α β α' β' :=
   newAnticipatedRDetEventfromOrdinary abs ev
 
 @[simp]
-def newAnticipatedSRDetEventfromOrdinary' [Preorder v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAnticipatedSRDetEventfromOrdinary' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : OrdinaryNDEvent AM α' Unit) (ev : AnticipatedRDetEventSpec' v AM M (α:=α) (α':=α') abs) : AnticipatedRDetEvent v AM M α Unit α' Unit :=
   newAnticipatedSRDetEventfromOrdinary abs ev.toAnticipatedRDetEventSpec
 
 @[simp]
-def newAnticipatedSRDetEventfromOrdinary'' [Preorder v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAnticipatedSRDetEventfromOrdinary'' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : OrdinaryNDEvent AM Unit Unit) (ev : AnticipatedRDetEventSpec'' v AM M abs) : AnticipatedRDetEvent v AM M Unit Unit :=
   newAnticipatedSRDetEventfromOrdinary abs ev.toAnticipatedRDetEventSpec
 
 @[simp]
-def newAnticipatedSRDetEventfromAnticipated [Preorder v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAnticipatedSRDetEventfromAnticipated [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : AnticipatedNDEvent v AM α' β') (ev : AnticipatedRDetEventSpec v AM M (α:=α) (β:=β) (α':=α') (β':=β') abs.toOrdinaryNDEvent) : AnticipatedRDetEvent v AM M α β α' β' :=
   newAnticipatedRDetEventfromAnticipated abs ev
 
 @[simp]
-def newAnticipatedSRDetEventfromAnticipated' [Preorder v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAnticipatedSRDetEventfromAnticipated' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : AnticipatedNDEvent v AM α' Unit) (ev : AnticipatedRDetEventSpec' v AM M (α:=α) (α':=α') abs.toOrdinaryNDEvent) : AnticipatedRDetEvent v AM M α Unit α' Unit :=
   newAnticipatedSRDetEventfromAnticipated abs ev.toAnticipatedRDetEventSpec
 
 @[simp]
-def newAnticipatedSRDetEventfromAnticipated'' [Preorder v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newAnticipatedSRDetEventfromAnticipated'' [Preorder v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : AnticipatedNDEvent v AM Unit Unit) (ev : AnticipatedRDetEventSpec'' v AM M abs.toOrdinaryNDEvent) : AnticipatedRDetEvent v AM M Unit Unit :=
   newAnticipatedSRDetEventfromAnticipated abs ev.toAnticipatedRDetEventSpec
 
 @[simp]
-def newConvergentSRDetEvent [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newConvergentSRDetEvent [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : OrdinaryNDEvent AM α' β') (ev : ConvergentRDetEventSpec v AM M (α:=α) (β:=β) (α':=α') (β':=β') abs) : ConvergentRDetEvent v AM M α β α' β' :=
   newConvergentRDetEvent abs ev
 
 @[simp]
-def newConvergentSRDetEvent' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newConvergentSRDetEvent' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : OrdinaryNDEvent AM α' Unit) (ev : ConvergentRDetEventSpec' v AM M (α:=α) (α':=α') abs) : ConvergentRDetEvent v AM M α Unit α' Unit :=
   newConvergentSRDetEvent abs ev.toConvergentRDetEventSpec
 
 @[simp]
-def newConvergentSRDetEvent'' [Preorder v] [WellFoundedLT v] [Machine ACTX AM] [Machine CTX M] [SRefinement AM M]
+def newConvergentSRDetEvent'' [Preorder v] [WellFoundedLT v] [@Machine ACTX AM] [@Machine CTX M] [SRefinement AM M]
   (abs : OrdinaryNDEvent AM Unit Unit) (ev : ConvergentRDetEventSpec'' v AM M abs) : ConvergentRDetEvent v AM M Unit Unit :=
   newConvergentSRDetEvent abs ev.toConvergentRDetEventSpec


### PR DESCRIPTION
Instead of makeing the context part of a machine an explicit parameter, this is a tentative variant of the framework in which the parameter becomes implicit.  Sadly, the implicit argument synthesizing algorithm does not handle the kind of dependency involved here. So this is probably a dead end.